### PR TITLE
ui: Add camera selector to input

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -116,6 +117,44 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.1",
@@ -782,10 +821,80 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
       "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
+      "integrity": "sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
+      "integrity": "sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.0",
@@ -846,6 +955,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -953,6 +1077,53 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
+      "integrity": "sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
@@ -1005,6 +1176,49 @@
       "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.2.tgz",
+      "integrity": "sha512-rZJtWmorC7dFRi0owDmoijm6nSJH1tVw64QGiNIZ9PNLyBDtG+iAq+XGsya052At4BfarzY/Dhv9wrrUr6IMZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1099,6 +1313,86 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
+      "integrity": "sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/ui/src/components/room.tsx
+++ b/ui/src/components/room.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
 import { PeerConnector } from "@/components/peer";
+import { StreamConfig, StreamSettings } from "@/components/settings";
 import { Webcam } from "@/components/webcam";
-import { StreamSettings, StreamConfig } from "@/components/settings";
 import { usePeerContext } from "@/context/peer-context";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 interface MediaStreamPlayerProps {
@@ -79,19 +79,19 @@ export function Room() {
 
   const connectingRef = useRef(false);
 
-  const onStreamReady = (stream: MediaStream) => {
+  const onStreamReady = useCallback((stream: MediaStream) => {
     setLocalStream(stream);
-  };
+  }, []);
 
-  const onRemoteStreamReady = () => {
+  const onRemoteStreamReady = useCallback(() => {
     toast.success("Started stream!", { id: loadingToastId });
     setLoadingToastId(undefined);
-  };
+  }, [loadingToastId]);
 
-  const onStreamConfigSave = async (config: StreamConfig) => {
+  const onStreamConfigSave = useCallback((config: StreamConfig) => {
     setStreamUrl(config.streamUrl);
     setPrompt(config.prompt);
-  };
+  }, []);
 
   useEffect(() => {
     if (connectingRef.current) return;
@@ -108,19 +108,19 @@ export function Room() {
     }
   }, [streamUrl]);
 
-  const handleConnected = () => {
+  const handleConnected = useCallback(() => {
     setIsConnected(true);
 
     console.debug("Connected!");
 
     connectingRef.current = false;
-  };
+  }, []);
 
-  const handleDisconnected = () => {
+  const handleDisconnected = useCallback(() => {
     setIsConnected(false);
 
     console.debug("Disconnected!");
-  };
+  }, []);
 
   return (
     <main className="fixed inset-0 overflow-hidden overscroll-none">

--- a/ui/src/components/room.tsx
+++ b/ui/src/components/room.tsx
@@ -76,6 +76,7 @@ export function Room() {
 
   const [streamUrl, setStreamUrl] = useState<string>("");
   const [prompt, setPrompt] = useState<any>(null);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string>("");
 
   const connectingRef = useRef(false);
 
@@ -91,6 +92,7 @@ export function Room() {
   const onStreamConfigSave = useCallback((config: StreamConfig) => {
     setStreamUrl(config.streamUrl);
     setPrompt(config.prompt);
+    setSelectedDeviceId(config.selectedDeviceId || "");
   }, []);
 
   useEffect(() => {
@@ -146,13 +148,14 @@ export function Room() {
                 />
               </div>
               <div className="landscape:w-full lg:w-1/2 h-[50dvh] lg:h-auto landscape:h-full max-w-[512px] max-h-[512px] aspect-square flex justify-center items-center lg:border-2 lg:rounded-md">
-                <Webcam onStreamReady={onStreamReady} />
+                <Webcam onStreamReady={onStreamReady} deviceId={selectedDeviceId} />
               </div>
             </div>
 
             <StreamSettings
               open={isStreamSettingsOpen}
               onOpenChange={setIsStreamSettingsOpen}
+              onDeviceChange={setSelectedDeviceId}
               onSave={onStreamConfigSave}
             />
           </div>

--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -1,19 +1,16 @@
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import {
   Form,
   FormControl,
@@ -22,14 +19,24 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Select } from "./ui/select";
 
 export interface StreamConfig {
   streamUrl: string;
   prompt?: any;
+  selectedDeviceId?: string;
+}
+
+interface VideoDevice {
+  deviceId: string;
+  label: string;
 }
 
 const DEFAULT_CONFIG: StreamConfig = {
@@ -40,12 +47,14 @@ const DEFAULT_CONFIG: StreamConfig = {
 interface StreamSettingsProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onDeviceChange: (deviceId: string) => void;
   onSave: (config: StreamConfig) => void;
 }
 
 export function StreamSettings({
   open,
   onOpenChange,
+  onDeviceChange,
   onSave,
 }: StreamSettingsProps) {
   const isDesktop = useMediaQuery("(min-width: 768px)");
@@ -67,7 +76,7 @@ export function StreamSettings({
               <div className="mt-4">Stream Settings</div>
             </DialogTitle>
           </DialogHeader>
-          <ConfigForm config={config} onSubmit={handleSubmit} />
+          <ConfigForm config={config} onDeviceChange={onDeviceChange} onSubmit={handleSubmit} />
         </DialogContent>
       </Dialog>
     );
@@ -80,7 +89,7 @@ export function StreamSettings({
           <DrawerTitle>Stream Settings</DrawerTitle>
         </DrawerHeader>
         <div className="px-4">
-          <ConfigForm config={config} onSubmit={handleSubmit} />
+          <ConfigForm config={config} onDeviceChange={onDeviceChange} onSubmit={handleSubmit} />
         </div>
       </DrawerContent>
     </Drawer>
@@ -93,16 +102,53 @@ const formSchema = z.object({
 
 interface ConfigFormProps {
   config: StreamConfig;
+  onDeviceChange: (deviceId: string) => void;
   onSubmit: (config: StreamConfig) => void;
 }
 
-function ConfigForm({ config, onSubmit }: ConfigFormProps) {
+function ConfigForm({ config, onDeviceChange, onSubmit }: ConfigFormProps) {
   const [prompt, setPrompt] = useState<any>(null);
+  const [videoDevices, setVideoDevices] = useState<VideoDevice[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<string>("");
+
+  useEffect(() => {
+    onDeviceChange(selectedDevice);
+  }, [selectedDevice]);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: config,
   });
+
+  const getVideoDevices = useCallback(async () => {
+    try {
+      await navigator.mediaDevices.getUserMedia({ video: true });
+
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = devices
+        .filter(device => device.kind === 'videoinput')
+        .map(device => ({
+          deviceId: device.deviceId,
+          label: device.label || `Camera ${device.deviceId.slice(0, 5)}...`
+        }));
+
+      setVideoDevices(videoDevices);
+      if (videoDevices.length > 0) {
+        setSelectedDevice(curr => curr || videoDevices[0].deviceId);
+      }
+    } catch (err) {
+      console.error('Failed to get video devices');
+    }
+  }, []);
+
+  useEffect(() => {
+    getVideoDevices();
+    navigator.mediaDevices.addEventListener('devicechange', getVideoDevices);
+
+    return () => {
+      navigator.mediaDevices.removeEventListener('devicechange', getVideoDevices);
+    };
+  }, [getVideoDevices]);
 
   const handleSubmit = (values: z.infer<typeof formSchema>) => {
     onSubmit({
@@ -111,6 +157,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
         ? values.streamUrl.replace(/\/+$/, "")
         : values.streamUrl,
       prompt,
+      selectedDeviceId: selectedDevice,
     });
   };
 
@@ -151,6 +198,25 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             accept=".json"
             onChange={handlePromptChange}
           ></Input>
+        </div>
+
+        <div className="mt-6 mb-4">
+          <Label>Camera</Label>
+          <Select
+            value={selectedDevice}
+            onValueChange={setSelectedDevice}
+          >
+            <Select.Trigger className="w-full mt-2">
+              {videoDevices.find(d => d.deviceId === selectedDevice)?.label || 'Select camera'}
+            </Select.Trigger>
+            <Select.Content>
+              {videoDevices.map((device) => (
+                <Select.Option key={device.deviceId} value={device.deviceId}>
+                  {device.label}
+                </Select.Option>
+              ))}
+            </Select.Content>
+          </Select>
         </div>
 
         <Button type="submit" className="w-full mt-4 mb-4">

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -1,0 +1,89 @@
+import { cn } from "@/lib/utils"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown } from "lucide-react"
+import * as React from "react"
+
+const Select = SelectPrimitive.Root as {
+  (props: SelectPrimitive.SelectProps): JSX.Element
+  Trigger: typeof SelectTrigger
+  Content: typeof SelectContent
+  Option: typeof SelectOption
+}
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectOption = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectOption.displayName = SelectPrimitive.Item.displayName
+
+Select.Trigger = SelectTrigger
+Select.Content = SelectContent
+Select.Option = SelectOption
+
+export { Select }

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -1,59 +1,144 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Select } from "./ui/select";
 
 interface WebcamProps {
   onStreamReady: (stream: MediaStream) => void;
 }
 
+interface VideoDevice {
+  deviceId: string;
+  label: string;
+}
+
 export function Webcam({ onStreamReady }: WebcamProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const [videoDevices, setVideoDevices] = useState<VideoDevice[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<string>("");
+  const [error, setError] = useState<string>("");
+
+  const getVideoDevices = useCallback(async () => {
+    try {
+      await navigator.mediaDevices.getUserMedia({ video: true });
+
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = devices
+        .filter(device => device.kind === 'videoinput')
+        .map(device => ({
+          deviceId: device.deviceId,
+          label: device.label || `Camera ${device.deviceId.slice(0, 5)}...`
+        }));
+
+      setVideoDevices(videoDevices);
+      if (videoDevices.length > 0 && !selectedDevice) {
+        setSelectedDevice(videoDevices[0].deviceId);
+      }
+    } catch (err) {
+      setError('Failed to get video devices');
+    }
+  }, []);
 
   const captureStream = useCallback(() => {
-    if (videoRef.current) {
-      // cast to any because captureStream() not recognized
-      const video = videoRef.current as any;
-      const stream = video.captureStream(30);
-
-      streamRef.current = stream;
-
-      onStreamReady(stream);
+    if (videoRef.current && !streamRef.current) {
+      try {
+        const video = videoRef.current as any;
+        const stream = video.captureStream(30);
+        streamRef.current = stream;
+        onStreamReady(stream);
+      } catch (err) {
+        setError('Failed to capture stream');
+      }
     }
   }, [onStreamReady]);
 
-  useEffect(() => {
-    const startWebcam = async () => {
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            width: { exact: 512 },
-            height: { exact: 512 },
-          },
-        });
+  const startWebcam = useCallback(async () => {
+    if (!selectedDevice) return;
 
-        if (videoRef.current) videoRef.current.srcObject = stream;
-
-        captureStream();
-      } catch (err) {
-        console.error(err);
+    try {
+      if (videoRef.current?.srcObject instanceof MediaStream) {
+        const tracks = videoRef.current.srcObject.getTracks();
+        tracks.forEach((track: MediaStreamTrack) => track.stop());
       }
-    };
 
-    startWebcam();
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach(track => track.stop());
+        streamRef.current = null;
+      }
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          deviceId: { exact: selectedDevice },
+          width: { ideal: 512 },
+          height: { ideal: 512 },
+        },
+        audio: false
+      });
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        videoRef.current.onloadedmetadata = () => {
+          videoRef.current?.play().catch(console.error);
+          captureStream();
+        };
+        videoRef.current.onerror = () => {
+          setError('Video playback error');
+        };
+      }
+    } catch (err) {
+      setError('Failed to start webcam');
+    }
+  }, [selectedDevice, captureStream]);
+
+  // Initial setup
+  useEffect(() => {
+    getVideoDevices();
+    navigator.mediaDevices.addEventListener('devicechange', getVideoDevices);
 
     return () => {
-      if (
-        videoRef.current &&
-        videoRef.current.srcObject instanceof MediaStream
-      ) {
+      navigator.mediaDevices.removeEventListener('devicechange', getVideoDevices);
+      if (videoRef.current?.srcObject instanceof MediaStream) {
         const tracks = videoRef.current.srcObject.getTracks();
         tracks.forEach((track: MediaStreamTrack) => track.stop());
       }
     };
-  }, []);
+  }, [getVideoDevices]);
+
+  // Handle device selection changes
+  useEffect(() => {
+    if (selectedDevice) {
+      startWebcam();
+    }
+  }, [selectedDevice, startWebcam]);
 
   return (
-    <div>
-      <video ref={videoRef} autoPlay playsInline />
+    <div className="space-y-4">
+      {error && (
+        <div className="text-red-500 text-sm">{error}</div>
+      )}
+      {videoDevices.length > 1 && (
+        <Select
+          value={selectedDevice}
+          onValueChange={setSelectedDevice}
+        >
+          <Select.Trigger className="w-[200px]">
+            {videoDevices.find(d => d.deviceId === selectedDevice)?.label || 'Select camera'}
+          </Select.Trigger>
+          <Select.Content>
+            {videoDevices.map((device) => (
+              <Select.Option key={device.deviceId} value={device.deviceId}>
+                {device.label}
+              </Select.Option>
+            ))}
+          </Select.Content>
+        </Select>
+      )}
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted
+        className="rounded-lg w-[512px] h-[512px] object-cover bg-black"
+      />
     </div>
   );
 }

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -1,148 +1,70 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Select } from "./ui/select";
+import { useCallback, useEffect, useRef } from "react";
 
 interface WebcamProps {
   onStreamReady: (stream: MediaStream) => void;
-}
-
-interface VideoDevice {
   deviceId: string;
-  label: string;
 }
 
-export function Webcam({ onStreamReady }: WebcamProps) {
+export function Webcam({ onStreamReady, deviceId }: WebcamProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
-  const [videoDevices, setVideoDevices] = useState<VideoDevice[]>([]);
-  const [selectedDevice, setSelectedDevice] = useState<string>("");
-  const [error, setError] = useState<string>("");
-
-  const getVideoDevices = useCallback(async () => {
-    try {
-      await navigator.mediaDevices.getUserMedia({ video: true });
-
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const videoDevices = devices
-        .filter(device => device.kind === 'videoinput')
-        .map(device => ({
-          deviceId: device.deviceId,
-          label: device.label || `Camera ${device.deviceId.slice(0, 5)}...`
-        }));
-
-      setVideoDevices(videoDevices);
-      if (videoDevices.length > 0 && !selectedDevice) {
-        setSelectedDevice(videoDevices[0].deviceId);
-      }
-    } catch (err) {
-      setError('Failed to get video devices');
-    }
-  }, []);
 
   const captureStream = useCallback(() => {
     if (videoRef.current && !streamRef.current) {
-      try {
-        const video = videoRef.current as any;
-        const stream = video.captureStream(30);
-        streamRef.current = stream;
-        onStreamReady(stream);
-      } catch (err) {
-        setError('Failed to capture stream');
-      }
+      const video = videoRef.current as any;
+      const stream = video.captureStream(30);
+      streamRef.current = stream;
+      onStreamReady(stream);
     }
   }, [onStreamReady]);
 
   const startWebcam = useCallback(async () => {
-    if (!selectedDevice) return;
+    if (!deviceId) return;
 
-    try {
-      if (videoRef.current?.srcObject instanceof MediaStream) {
-        const tracks = videoRef.current.srcObject.getTracks();
-        tracks.forEach((track: MediaStreamTrack) => track.stop());
-      }
-
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach(track => track.stop());
-        streamRef.current = null;
-      }
-
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: {
-          deviceId: { exact: selectedDevice },
-          width: { ideal: 512 },
-          height: { ideal: 512 },
-        },
-        audio: false
-      });
-
-      if (videoRef.current) {
-        videoRef.current.srcObject = stream;
-        videoRef.current.onloadedmetadata = () => {
-          videoRef.current?.play().catch(console.error);
-          captureStream();
-        };
-        videoRef.current.onerror = () => {
-          setError('Video playback error');
-        };
-      }
-    } catch (err) {
-      setError('Failed to start webcam');
+    if (videoRef.current?.srcObject instanceof MediaStream) {
+      const tracks = videoRef.current.srcObject.getTracks();
+      tracks.forEach((track: MediaStreamTrack) => track.stop());
     }
-  }, [selectedDevice, captureStream]);
 
-  // Initial setup
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(track => track.stop());
+      streamRef.current = null;
+    }
+
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: {
+        deviceId: { exact: deviceId },
+        width: { ideal: 512 },
+        height: { ideal: 512 },
+      },
+      audio: false
+    });
+
+    if (videoRef.current) {
+      videoRef.current.srcObject = stream;
+      videoRef.current.onloadedmetadata = () => {
+        videoRef.current?.play().catch(console.error);
+        captureStream();
+      };
+    }
+  }, [deviceId, captureStream]);
+
   useEffect(() => {
-    getVideoDevices();
-    navigator.mediaDevices.addEventListener('devicechange', getVideoDevices);
+    if (deviceId) {
+      startWebcam();
+    }
 
     return () => {
-      navigator.mediaDevices.removeEventListener('devicechange', getVideoDevices);
       if (videoRef.current?.srcObject instanceof MediaStream) {
         const tracks = videoRef.current.srcObject.getTracks();
         tracks.forEach((track: MediaStreamTrack) => track.stop());
       }
     };
-  }, [getVideoDevices]);
-
-  // Handle device selection changes
-  useEffect(() => {
-    if (selectedDevice) {
-      startWebcam();
-    }
-  }, [selectedDevice, startWebcam]);
+  }, [deviceId, startWebcam]);
 
   return (
-    <div className="relative">
-      {error && (
-        <div className="text-red-500 text-sm">{error}</div>
-      )}
-      <div className="relative border-2 border-gray-300 rounded-lg overflow-hidden">
-        <video
-          ref={videoRef}
-          autoPlay
-          playsInline
-          muted
-          className="w-[512px] h-[512px] object-cover bg-black"
-        />
-        {videoDevices.length > 1 && (
-          <div className="absolute inset-0 flex items-end justify-center pb-4">
-            <Select
-              value={selectedDevice}
-              onValueChange={setSelectedDevice}
-            >
-              <Select.Trigger className="w-[200px]">
-                {videoDevices.find(d => d.deviceId === selectedDevice)?.label || 'Select camera'}
-              </Select.Trigger>
-              <Select.Content>
-                {videoDevices.map((device) => (
-                  <Select.Option key={device.deviceId} value={device.deviceId}>
-                    {device.label}
-                  </Select.Option>
-                ))}
-              </Select.Content>
-            </Select>
-          </div>
-        )}
-      </div>
+    <div>
+      <video ref={videoRef} autoPlay playsInline />
     </div>
   );
 }

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -11,9 +11,12 @@ export function Webcam({ onStreamReady, deviceId }: WebcamProps) {
 
   const captureStream = useCallback(() => {
     if (videoRef.current && !streamRef.current) {
+      // cast to any because captureStream() not recognized
       const video = videoRef.current as any;
       const stream = video.captureStream(30);
+
       streamRef.current = stream;
+
       onStreamReady(stream);
     }
   }, [onStreamReady]);
@@ -33,19 +36,15 @@ export function Webcam({ onStreamReady, deviceId }: WebcamProps) {
 
     const stream = await navigator.mediaDevices.getUserMedia({
       video: {
-        deviceId: { exact: deviceId },
-        width: { ideal: 512 },
-        height: { ideal: 512 },
+        ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+        width: { exact: 512 },
+        height: { exact: 512 },
       },
-      audio: false
     });
 
     if (videoRef.current) {
       videoRef.current.srcObject = stream;
-      videoRef.current.onloadedmetadata = () => {
-        videoRef.current?.play().catch(console.error);
-        captureStream();
-      };
+      captureStream();
     }
   }, [deviceId, captureStream]);
 

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -115,13 +115,13 @@ export function Webcam({ onStreamReady }: WebcamProps) {
       {error && (
         <div className="text-red-500 text-sm">{error}</div>
       )}
-      <div className="relative">
+      <div className="relative border-2 border-gray-300 rounded-lg overflow-hidden">
         <video
           ref={videoRef}
           autoPlay
           playsInline
           muted
-          className="rounded-lg w-[512px] h-[512px] object-cover bg-black"
+          className="w-[512px] h-[512px] object-cover bg-black"
         />
         {videoDevices.length > 1 && (
           <div className="absolute inset-0 flex items-end justify-center pb-4">

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -37,8 +37,8 @@ export function Webcam({ onStreamReady, deviceId }: WebcamProps) {
     const stream = await navigator.mediaDevices.getUserMedia({
       video: {
         ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
-        width: { exact: 512 },
-        height: { exact: 512 },
+        width: { ideal: 512 },
+        height: { ideal: 512 },
       },
     });
 

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -111,34 +111,38 @@ export function Webcam({ onStreamReady }: WebcamProps) {
   }, [selectedDevice, startWebcam]);
 
   return (
-    <div className="space-y-4">
+    <div className="relative">
       {error && (
         <div className="text-red-500 text-sm">{error}</div>
       )}
-      {videoDevices.length > 1 && (
-        <Select
-          value={selectedDevice}
-          onValueChange={setSelectedDevice}
-        >
-          <Select.Trigger className="w-[200px]">
-            {videoDevices.find(d => d.deviceId === selectedDevice)?.label || 'Select camera'}
-          </Select.Trigger>
-          <Select.Content>
-            {videoDevices.map((device) => (
-              <Select.Option key={device.deviceId} value={device.deviceId}>
-                {device.label}
-              </Select.Option>
-            ))}
-          </Select.Content>
-        </Select>
-      )}
-      <video
-        ref={videoRef}
-        autoPlay
-        playsInline
-        muted
-        className="rounded-lg w-[512px] h-[512px] object-cover bg-black"
-      />
+      <div className="relative">
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted
+          className="rounded-lg w-[512px] h-[512px] object-cover bg-black"
+        />
+        {videoDevices.length > 1 && (
+          <div className="absolute inset-0 flex items-end justify-center pb-4">
+            <Select
+              value={selectedDevice}
+              onValueChange={setSelectedDevice}
+            >
+              <Select.Trigger className="w-[200px]">
+                {videoDevices.find(d => d.deviceId === selectedDevice)?.label || 'Select camera'}
+              </Select.Trigger>
+              <Select.Content>
+                {videoDevices.map((device) => (
+                  <Select.Option key={device.deviceId} value={device.deviceId}>
+                    {device.label}
+                  </Select.Option>
+                ))}
+              </Select.Content>
+            </Select>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -1,4 +1,108 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Internal component that renders and captures camera feed at exactly 512x512.
+ * Handles both display and stream capture in a single canvas element,
+ * ensuring consistent dimensions while maintaining aspect ratio.
+ */
+function StreamCanvas({
+  stream,
+  onStreamReady,
+}: {
+  stream: MediaStream | null;
+  onStreamReady: (stream: MediaStream) => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() =>{
+    const canvas = canvasRef.current!;
+    const outputStream = canvas.captureStream(30);
+    onStreamReady(outputStream);
+
+    return () => {
+      outputStream.getTracks().forEach(track => track.stop());
+    }
+  }, [onStreamReady])
+
+  // Set up canvas animation loop
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext('2d')!;
+
+    let isActive = true;
+    const drawFrame = () => {
+      if (!isActive) {
+        // return without scheduling another frame
+        return
+      }
+      const video = videoRef.current!;
+      if (!video?.videoWidth) {
+        // video is not ready yet
+        requestAnimationFrame(drawFrame);
+        return
+      }
+
+      const scale = Math.max(
+        512 / video.videoWidth,
+        512 / video.videoHeight
+      );
+
+      const scaledWidth = video.videoWidth * scale;
+      const scaledHeight = video.videoHeight * scale;
+
+      const offsetX = (512 - scaledWidth) / 2;
+      const offsetY = (512 - scaledHeight) / 2;
+
+      ctx.fillStyle = 'black';
+      ctx.fillRect(0, 0, 512, 512);
+      ctx.drawImage(
+        video,
+        offsetX,
+        offsetY,
+        scaledWidth,
+        scaledHeight
+      );
+      requestAnimationFrame(drawFrame);
+    };
+    drawFrame();
+
+    return () => { isActive = false;};
+  }, []);
+
+  useEffect(() => {
+    if (!stream) return;
+    if (!videoRef.current) {
+      videoRef.current = document.createElement('video');
+      videoRef.current.muted = true;
+    }
+
+    const video = videoRef.current;
+    video.srcObject = stream;
+    video.onloadedmetadata = () => {
+      video.play().catch(error => {
+        console.log('Video play failed:', error);
+      });
+    };
+
+    return () => {
+      video.pause();
+      video.srcObject = null;
+    };
+  }, [stream]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={512}
+      height={512}
+      className="w-full h-full"
+      style={{
+        backgroundColor: 'black',
+      }}
+    />
+  );
+}
 
 interface WebcamProps {
   onStreamReady: (stream: MediaStream) => void;
@@ -6,64 +110,58 @@ interface WebcamProps {
 }
 
 export function Webcam({ onStreamReady, deviceId }: WebcamProps) {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const streamRef = useRef<MediaStream | null>(null);
+  const [stream, setStream] = useState<MediaStream | null>(null);
 
-  const captureStream = useCallback(() => {
-    if (videoRef.current && !streamRef.current) {
-      // cast to any because captureStream() not recognized
-      const video = videoRef.current as any;
-      const stream = video.captureStream(30);
-
-      streamRef.current = stream;
-
-      onStreamReady(stream);
-    }
-  }, [onStreamReady]);
+  const replaceStream = useCallback((newStream: MediaStream | null) => {
+    setStream(oldStream => {
+      // Clean up old stream if it exists
+      if (oldStream) {
+        oldStream.getTracks().forEach(track => track.stop());
+      }
+      if (newStream) {
+        const videoTrack = newStream.getVideoTracks()[0];
+        const settings = videoTrack.getSettings();
+      }
+      return newStream;
+    });
+  }, []);
 
   const startWebcam = useCallback(async () => {
-    if (!deviceId) return;
-
-    if (videoRef.current?.srcObject instanceof MediaStream) {
-      const tracks = videoRef.current.srcObject.getTracks();
-      tracks.forEach((track: MediaStreamTrack) => track.stop());
+    if (!deviceId) {
+      return null;
     }
 
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach(track => track.stop());
-      streamRef.current = null;
+    try {
+      const newStream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+          width: { ideal: 512 },
+          height: { ideal: 512 },
+          aspectRatio: { ideal: 1 },
+        },
+      });
+      return newStream;
+    } catch (error) {
+      return null;
     }
-
-    const stream = await navigator.mediaDevices.getUserMedia({
-      video: {
-        ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
-        width: { ideal: 512 },
-        height: { ideal: 512 },
-      },
-    });
-
-    if (videoRef.current) {
-      videoRef.current.srcObject = stream;
-      captureStream();
-    }
-  }, [deviceId, captureStream]);
+  }, [deviceId]);
 
   useEffect(() => {
-    if (deviceId) {
-      startWebcam();
-    }
+    if (!deviceId) return;
 
-    return () => {
-      if (videoRef.current?.srcObject instanceof MediaStream) {
-        const tracks = videoRef.current.srcObject.getTracks();
-        tracks.forEach((track: MediaStreamTrack) => track.stop());
-      }
-    };
-  }, [deviceId, startWebcam]);
+    startWebcam().then(newStream => {
+      replaceStream(newStream);
+    });
+
+    return () => { replaceStream(null) };
+  }, [deviceId, startWebcam, replaceStream]);
 
   return (
     <div>
-      <video ref={videoRef} autoPlay playsInline />
+      <StreamCanvas
+        stream={stream}
+        onStreamReady={onStreamReady}
+      />
     </div>
   );
 }

--- a/ui/src/hooks/use-peer.ts
+++ b/ui/src/hooks/use-peer.ts
@@ -158,7 +158,7 @@ export function usePeer(props: PeerProps): Peer {
         currentTracksRef.current = [];
       }
     }
-  }, [connect, localStream]);
+  }, [connect, peerConnection, localStream]);
 
   React.useEffect(() => {
     if (!peerConnection) return;


### PR DESCRIPTION
This is to allow changing the input camera when using the comfystream app. For example,
this will allow using a virtual camera from OBS as the input, which was the main goal and 
test scenario here.

I have also updated the `use-peer` logic to support updating the RTC connection when the
stream changes.

Notice that I wasn't able to run the `comfystream` flow E2E so was only able to test the
frontend select component, but not if the RTC logic works when we switch it. It could be
helpful to have an example comfyui workflow in the repo for easy testing.