### PR TITLE
feat: audio support 

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -9,6 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
     wget \
     nano \
     socat \
+    libsndfile1 \
     build-essential llvm tk-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/nodes/audio_utils/__init__.py
+++ b/nodes/audio_utils/__init__.py
@@ -1,0 +1,7 @@
+from .load_audio_tensor import LoadAudioTensor
+from .save_audio_tensor import SaveAudioTensor
+from .pitch_shift import PitchShifter
+
+NODE_CLASS_MAPPINGS = {"LoadAudioTensor": LoadAudioTensor, "SaveAudioTensor": SaveAudioTensor, "PitchShifter": PitchShifter}
+
+__all__ = ["NODE_CLASS_MAPPINGS"]

--- a/nodes/audio_utils/load_audio_tensor.py
+++ b/nodes/audio_utils/load_audio_tensor.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from comfystream import tensor_cache
+
+class LoadAudioTensor:
+    CATEGORY = "audio_utils"
+    RETURN_TYPES = ("WAVEFORM", "INT")
+    FUNCTION = "execute"
+    
+    def __init__(self):
+        self.audio_buffer = np.empty(0, dtype=np.int16)
+        self.buffer_samples = None
+        self.sample_rate = None
+    
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "buffer_size": ("FLOAT", {"default": 500.0}),
+            }
+        }
+    
+    @classmethod
+    def IS_CHANGED():
+        return float("nan")
+    
+    def execute(self, buffer_size):
+        if self.sample_rate is None or self.buffer_samples is None:
+            frame = tensor_cache.audio_inputs.get(block=True)
+            self.sample_rate = frame.sample_rate
+            self.buffer_samples = int(self.sample_rate * buffer_size / 1000)
+            self.leftover = frame.side_data.input
+        
+        if self.leftover.shape[0] < self.buffer_samples:
+            chunks = [self.leftover] if self.leftover.size > 0 else []
+            total_samples = self.leftover.shape[0]
+            
+            while total_samples < self.buffer_samples:
+                frame = tensor_cache.audio_inputs.get(block=True)
+                if frame.sample_rate != self.sample_rate:
+                    raise ValueError("Sample rate mismatch")
+                chunks.append(frame.side_data.input)
+                total_samples += frame.side_data.input.shape[0]
+            
+            merged_audio = np.concatenate(chunks, dtype=np.int16)
+            buffered_audio = merged_audio[:self.buffer_samples]
+            self.leftover = merged_audio[self.buffer_samples:]
+        else:
+            buffered_audio = self.leftover[:self.buffer_samples]
+            self.leftover = self.leftover[self.buffer_samples:]
+                
+        return buffered_audio, self.sample_rate

--- a/nodes/audio_utils/pitch_shift.py
+++ b/nodes/audio_utils/pitch_shift.py
@@ -1,0 +1,32 @@
+import numpy as np
+import librosa
+
+class PitchShifter:
+    CATEGORY = "audio_utils"
+    RETURN_TYPES = ("WAVEFORM", "INT")
+    FUNCTION = "execute"
+    
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "audio": ("WAVEFORM",),
+                "sample_rate": ("INT",),
+                "pitch_shift": ("FLOAT", {
+                    "default": 4.0, 
+                    "min": 0.0, 
+                    "max": 12.0, 
+                    "step": 0.5
+                }),
+            }
+        }
+
+    @classmethod
+    def IS_CHANGED(cls):
+        return float("nan")
+
+    def execute(self, audio, sample_rate, pitch_shift):
+        audio_float = audio.astype(np.float32) / 32768.0
+        shifted_audio = librosa.effects.pitch_shift(y=audio_float, sr=sample_rate, n_steps=pitch_shift)
+        shifted_int16 = np.clip(shifted_audio * 32768.0, -32768, 32767).astype(np.int16)
+        return shifted_int16, sample_rate

--- a/nodes/audio_utils/save_audio_tensor.py
+++ b/nodes/audio_utils/save_audio_tensor.py
@@ -1,19 +1,17 @@
-import torch
-
 from comfystream import tensor_cache
 
-
-class SaveTensor:
-    CATEGORY = "tensor_utils"
+class SaveAudioTensor:
+    CATEGORY = "audio_utils"
     RETURN_TYPES = ()
     FUNCTION = "execute"
     OUTPUT_NODE = True
+
 
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "images": ("IMAGE",),
+                "audio": ("WAVEFORM",)
             }
         }
 
@@ -21,6 +19,7 @@ class SaveTensor:
     def IS_CHANGED(s):
         return float("nan")
 
-    def execute(self, images: torch.Tensor):
-        tensor_cache.image_outputs.put_nowait(images)
-        return images
+    def execute(self, audio):
+        tensor_cache.audio_outputs.put_nowait(audio)
+        return (audio,)
+

--- a/nodes/tensor_utils/load_tensor.py
+++ b/nodes/tensor_utils/load_tensor.py
@@ -15,5 +15,6 @@ class LoadTensor:
         return float("nan")
 
     def execute(self):
-        input = tensor_cache.inputs.pop()
-        return (input,)
+        frame = tensor_cache.image_inputs.get(block=True)
+        frame.side_data.skipped = False
+        return (frame.side_data.input,)

--- a/server/app.py
+++ b/server/app.py
@@ -38,8 +38,12 @@ class VideoStreamTrack(MediaStreamTrack):
 
     async def collect_frames(self):
         while True:
-            frame = await self.track.recv()
-            await self.pipeline.put_video_frame(frame)
+            try:
+                frame = await self.track.recv()
+                await self.pipeline.put_video_frame(frame)
+            except Exception as e:
+                await self.pipeline.cleanup()
+                raise Exception(f"Error collecting video frames: {str(e)}")
 
     async def recv(self):
         return await self.pipeline.get_processed_video_frame()
@@ -55,8 +59,12 @@ class AudioStreamTrack(MediaStreamTrack):
 
     async def collect_frames(self):
         while True:
-            frame = await self.track.recv()
-            await self.pipeline.put_audio_frame(frame)
+            try:
+                frame = await self.track.recv()
+                await self.pipeline.put_audio_frame(frame)
+            except Exception as e:
+                await self.pipeline.cleanup()
+                raise Exception(f"Error collecting audio frames: {str(e)}")
 
     async def recv(self):
         return await self.pipeline.get_processed_audio_frame()

--- a/server/app.py
+++ b/server/app.py
@@ -30,15 +30,36 @@ MIN_BITRATE = 2000000
 
 class VideoStreamTrack(MediaStreamTrack):
     kind = "video"
-
     def __init__(self, track: MediaStreamTrack, pipeline):
         super().__init__()
         self.track = track
         self.pipeline = pipeline
+        asyncio.create_task(self.collect_frames())
+
+    async def collect_frames(self):
+        while True:
+            frame = await self.track.recv()
+            await self.pipeline.put_video_frame(frame)
 
     async def recv(self):
-        frame = await self.track.recv()
-        return await self.pipeline(frame)
+        return await self.pipeline.get_processed_video_frame()
+    
+
+class AudioStreamTrack(MediaStreamTrack):
+    kind = "audio"
+    def __init__(self, track: MediaStreamTrack, pipeline):
+        super().__init__()
+        self.track = track
+        self.pipeline = pipeline
+        asyncio.create_task(self.collect_frames())
+
+    async def collect_frames(self):
+        while True:
+            frame = await self.track.recv()
+            await self.pipeline.put_audio_frame(frame)
+
+    async def recv(self):
+        return await self.pipeline.get_processed_audio_frame()
 
 
 def force_codec(pc, sender, forced_codec):
@@ -87,8 +108,7 @@ async def offer(request):
 
     params = await request.json()
 
-    pipeline.set_prompt(params["prompt"])
-    await pipeline.warm()
+    await pipeline.set_prompts(params["prompts"])
 
     offer_params = params["offer"]
     offer = RTCSessionDescription(sdp=offer_params["sdp"], type=offer_params["type"])
@@ -103,17 +123,19 @@ async def offer(request):
 
     pcs.add(pc)
 
-    tracks = {"video": None}
+    tracks = {"video": None, "audio": None}
 
-    # Prefer h264
-    transceiver = pc.addTransceiver("video")
-    caps = RTCRtpSender.getCapabilities("video")
-    prefs = list(filter(lambda x: x.name == "H264", caps.codecs))
-    transceiver.setCodecPreferences(prefs)
+    # Only add video transceiver if video is present in the offer
+    if "m=video" in offer.sdp:
+        # Prefer h264
+        transceiver = pc.addTransceiver("video")
+        caps = RTCRtpSender.getCapabilities("video")
+        prefs = list(filter(lambda x: x.name == "H264", caps.codecs))
+        transceiver.setCodecPreferences(prefs)
 
-    # Monkey patch max and min bitrate to ensure constant bitrate
-    h264.MAX_BITRATE = MAX_BITRATE
-    h264.MIN_BITRATE = MIN_BITRATE
+        # Monkey patch max and min bitrate to ensure constant bitrate
+        h264.MAX_BITRATE = MAX_BITRATE
+        h264.MIN_BITRATE = MIN_BITRATE
 
     # Handle control channel from client
     @pc.on("datachannel")
@@ -131,13 +153,13 @@ async def offer(request):
                             "nodes": nodes_info
                         }
                         channel.send(json.dumps(response))
-                    elif params.get("type") == "update_prompt":
-                        if "prompt" not in params:
+                    elif params.get("type") == "update_prompts":
+                        if "prompts" not in params:
                             logger.warning("[Control] Missing prompt in update_prompt message")
                             return
-                        pipeline.set_prompt(params["prompt"])
+                        await pipeline.update_prompts(params["prompts"])
                         response = {
-                            "type": "prompt_updated",
+                            "type": "prompts_updated",
                             "success": True
                         }
                         channel.send(json.dumps(response))
@@ -158,6 +180,10 @@ async def offer(request):
 
             codec = "video/H264"
             force_codec(pc, sender, codec)
+        elif track.kind == "audio":
+            audioTrack = AudioStreamTrack(track, pipeline)
+            tracks["audio"] = audioTrack
+            pc.addTrack(audioTrack)
 
         @track.on("ended")
         async def on_ended():
@@ -175,6 +201,11 @@ async def offer(request):
 
     await pc.setRemoteDescription(offer)
 
+    if "m=audio" in pc.remoteDescription.sdp:
+        await pipeline.warm_audio()
+    if "m=video" in pc.remoteDescription.sdp:
+        await pipeline.warm_video()
+
     answer = await pc.createAnswer()
     await pc.setLocalDescription(answer)
 
@@ -190,7 +221,7 @@ async def set_prompt(request):
     pipeline = request.app["pipeline"]
 
     prompt = await request.json()
-    pipeline.set_prompt(prompt)
+    await pipeline.set_prompts(prompt)
 
     return web.Response(content_type="application/json", text="OK")
 

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -107,3 +107,6 @@ class Pipeline:
         """Get information about all nodes in the current prompt including metadata."""
         nodes_info = await self.client.get_available_nodes()
         return nodes_info
+    
+    async def cleanup(self):
+        await self.client.cleanup()

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -1,49 +1,108 @@
-import torch
 import av
+import torch
 import numpy as np
+import asyncio
 
-from typing import Any, Dict
+from typing import Any, Dict, Union, List
 from comfystream.client import ComfyStreamClient
 
 WARMUP_RUNS = 5
 
 
-
 class Pipeline:
     def __init__(self, **kwargs):
-        self.client = ComfyStreamClient(**kwargs)
+        self.client = ComfyStreamClient(**kwargs, max_workers=5) # TODO: hardcoded max workers, should it be configurable?
 
-    def set_prompt(self, prompt: Dict[Any, Any]):
-        self.client.set_prompt(prompt)
+        self.video_incoming_frames = asyncio.Queue()
+        self.audio_incoming_frames = asyncio.Queue()
 
-    async def warm(self):
-        frame = torch.randn(1, 512, 512, 3)
+        self.processed_audio_buffer = np.array([], dtype=np.int16)
+
+    async def warm_video(self):
+        dummy_frame = av.VideoFrame()
+        dummy_frame.side_data.input = torch.randn(1, 512, 512, 3)
 
         for _ in range(WARMUP_RUNS):
-            await self.predict(frame)
+            self.client.put_video_input(dummy_frame)
+            await self.client.get_video_output()
 
-    def preprocess(self, frame: av.VideoFrame) -> torch.Tensor:
+    async def warm_audio(self):
+        dummy_frame = av.AudioFrame()
+        dummy_frame.side_data.input = np.random.randint(-32768, 32767, int(48000 * 0.5), dtype=np.int16)   # TODO: adds a lot of delay if it doesn't match the buffer size, is warmup needed?
+        dummy_frame.sample_rate = 48000
+
+        for _ in range(WARMUP_RUNS):
+            self.client.put_audio_input(dummy_frame)
+            await self.client.get_audio_output()
+
+    async def set_prompts(self, prompts: Union[Dict[Any, Any], List[Dict[Any, Any]]]):
+        if isinstance(prompts, list):
+            await self.client.set_prompts(prompts)
+        else:
+            await self.client.set_prompts([prompts])
+
+    async def update_prompts(self, prompts: Union[Dict[Any, Any], List[Dict[Any, Any]]]):
+        if isinstance(prompts, list):
+            await self.client.update_prompts(prompts)
+        else:
+            await self.client.update_prompts([prompts])
+
+    async def put_video_frame(self, frame: av.VideoFrame):
+        frame.side_data.input = self.video_preprocess(frame)
+        frame.side_data.skipped = True
+        self.client.put_video_input(frame)
+        await self.video_incoming_frames.put(frame)
+
+    async def put_audio_frame(self, frame: av.AudioFrame):
+        frame.side_data.input = self.audio_preprocess(frame)
+        frame.side_data.skipped = True
+        self.client.put_audio_input(frame)
+        await self.audio_incoming_frames.put(frame)
+
+    def video_preprocess(self, frame: av.VideoFrame) -> Union[torch.Tensor, np.ndarray]:
         frame_np = frame.to_ndarray(format="rgb24").astype(np.float32) / 255.0
         return torch.from_numpy(frame_np).unsqueeze(0)
-
-    async def predict(self, frame: torch.Tensor) -> torch.Tensor:
-        return await self.client.queue_prompt(frame)
-
-    def postprocess(self, frame: torch.Tensor) -> av.VideoFrame:
+    
+    def audio_preprocess(self, frame: av.AudioFrame) -> Union[torch.Tensor, np.ndarray]:
+        return frame.to_ndarray().ravel().reshape(-1, 2).mean(axis=1).astype(np.int16)
+    
+    def video_postprocess(self, output: Union[torch.Tensor, np.ndarray]) -> av.VideoFrame:
         return av.VideoFrame.from_ndarray(
-            (frame * 255.0).clamp(0, 255).to(dtype=torch.uint8).squeeze(0).cpu().numpy()
+            (output * 255.0).clamp(0, 255).to(dtype=torch.uint8).squeeze(0).cpu().numpy()
         )
 
-    async def __call__(self, frame: av.VideoFrame) -> av.VideoFrame:
-        pre_output = self.preprocess(frame)
-        pred_output = await self.predict(pre_output)
-        post_output = self.postprocess(pred_output)
+    def audio_postprocess(self, output: Union[torch.Tensor, np.ndarray]) -> av.AudioFrame:
+        return av.AudioFrame.from_ndarray(np.repeat(output, 2).reshape(1, -1))
+    
+    async def get_processed_video_frame(self):
+        # TODO: make it generic to support purely generative video cases
+        out_tensor = await self.client.get_video_output()
+        frame = await self.video_incoming_frames.get()
+        while frame.side_data.skipped:
+            frame = await self.video_incoming_frames.get()
 
-        post_output.pts = frame.pts
-        post_output.time_base = frame.time_base
+        processed_frame  = self.video_postprocess(out_tensor)
+        processed_frame.pts = frame.pts
+        processed_frame.time_base = frame.time_base
+        
+        return processed_frame
 
-        return post_output
+    async def get_processed_audio_frame(self):
+        # TODO: make it generic to support purely generative audio cases and also add frame skipping
+        frame = await self.audio_incoming_frames.get()
+        if frame.samples > len(self.processed_audio_buffer):
+            out_tensor = await self.client.get_audio_output()
+            self.processed_audio_buffer = np.concatenate([self.processed_audio_buffer, out_tensor])
+        out_data = self.processed_audio_buffer[:frame.samples]
+        self.processed_audio_buffer = self.processed_audio_buffer[frame.samples:]
 
+        processed_frame = self.audio_postprocess(out_data)
+        processed_frame.pts = frame.pts
+        processed_frame.time_base = frame.time_base
+        processed_frame.sample_rate = frame.sample_rate
+        
+        return processed_frame
+    
     async def get_nodes_info(self) -> Dict[str, Any]:
         """Get information about all nodes in the current prompt including metadata."""
         nodes_info = await self.client.get_available_nodes()

--- a/src/comfystream/tensor_cache.py
+++ b/src/comfystream/tensor_cache.py
@@ -1,6 +1,14 @@
-import asyncio
 import torch
-from typing import List
+import numpy as np
 
-inputs: List[torch.Tensor] = []
-outputs: List[asyncio.Future] = []
+from queue import Queue
+from asyncio import Queue as AsyncQueue
+
+from typing import Union
+
+# TODO: improve eviction policy fifo might not be the best, skip alternate frames instead
+image_inputs: Queue[Union[torch.Tensor, np.ndarray]] = Queue(maxsize=1)
+image_outputs: AsyncQueue[Union[torch.Tensor, np.ndarray]] = AsyncQueue()
+
+audio_inputs: Queue[Union[torch.Tensor, np.ndarray]] = Queue()
+audio_outputs: AsyncQueue[Union[torch.Tensor, np.ndarray]] = AsyncQueue()

--- a/src/comfystream/utils.py
+++ b/src/comfystream/utils.py
@@ -36,7 +36,7 @@ def convert_prompt(prompt: PromptDictInput) -> Prompt:
         "PreviewImage": [],
         "SaveImage": [],
     }
-
+    
     for key, node in prompt.items():
         class_type = node.get("class_type")
 
@@ -47,9 +47,9 @@ def convert_prompt(prompt: PromptDictInput) -> Prompt:
         # Count inputs and outputs
         if class_type == "PrimaryInputLoadImage":
             num_primary_inputs += 1
-        elif class_type in ["LoadImage", "LoadTensor"]:
+        elif class_type in ["LoadImage", "LoadTensor", "LoadAudioTensor"]:
             num_inputs += 1
-        elif class_type in ["PreviewImage", "SaveImage", "SaveTensor"]:
+        elif class_type in ["PreviewImage", "SaveImage", "SaveTensor", "SaveAudioTensor"]:
             num_outputs += 1
 
     # Only handle single primary input

--- a/ui/src/app/api/offer/route.ts
+++ b/ui/src/app/api/offer/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async function POST(req: NextRequest) {
-  const { endpoint, prompt, offer } = await req.json();
+  const { endpoint, prompts, offer } = await req.json();
 
   const res = await fetch(endpoint + "/offer", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ prompt, offer }),
+    body: JSON.stringify({ prompts, offer }),
   });
 
   return NextResponse.json(await res.json(), { status: res.status });

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -5,22 +5,22 @@ import { PromptContext } from "@/components/settings";
 import { useState, useEffect } from "react";
 
 export default function Page() {
-  const [originalPrompt, setOriginalPrompt] = useState<any>(null);
-  const [currentPrompt, setCurrentPrompt] = useState<any>(null);
+  const [originalPrompts, setOriginalPrompts] = useState<any>(null);
+  const [currentPrompts, setCurrentPrompts] = useState<any>(null);
 
   // Update currentPrompt whenever originalPrompt changes
   useEffect(() => {
-    if (originalPrompt) {
-      setCurrentPrompt(JSON.parse(JSON.stringify(originalPrompt)));
+    if (originalPrompts) {
+      setCurrentPrompts(JSON.parse(JSON.stringify(originalPrompts)));
     }
-  }, [originalPrompt]);
+  }, [originalPrompts]);
 
   return (
     <PromptContext.Provider value={{ 
-      originalPrompt, 
-      currentPrompt,
-      setOriginalPrompt, 
-      setCurrentPrompt 
+      originalPrompts, 
+      currentPrompts,
+      setOriginalPrompts, 
+      setCurrentPrompts 
     }}>
       <div className="flex flex-col">
         <div className="w-full">

--- a/ui/src/components/peer.tsx
+++ b/ui/src/components/peer.tsx
@@ -4,7 +4,7 @@ import { PeerContext } from "@/context/peer-context";
 
 export interface PeerProps extends React.HTMLAttributes<HTMLDivElement> {
   url: string;
-  prompt: any;
+  prompts: any;
   connect: boolean;
   onConnected: () => void;
   onDisconnected: () => void;

--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -40,8 +40,9 @@ import { Select } from "./ui/select";
 export interface StreamConfig {
   streamUrl: string;
   frameRate: number;
-  prompt?: any;
+  prompts?: any;
   selectedDeviceId: string | undefined;
+  selectedAudioDeviceId: string | undefined;
 }
 
 interface VideoDevice {
@@ -54,6 +55,7 @@ export const DEFAULT_CONFIG: StreamConfig = {
     process.env.NEXT_PUBLIC_DEFAULT_STREAM_URL || "http://127.0.0.1:8889",
   frameRate: 30,
   selectedDeviceId: undefined,
+  selectedAudioDeviceId: undefined,
 };
 
 interface StreamSettingsProps {
@@ -117,28 +119,28 @@ interface ConfigFormProps {
 }
 
 interface PromptContextType {
-  originalPrompt: any;
-  currentPrompt: any;
-  setOriginalPrompt: (prompt: any) => void;
-  setCurrentPrompt: (prompt: any) => void;
+  originalPrompts: any;
+  currentPrompts: any;
+  setOriginalPrompts: (prompts: any) => void;
+  setCurrentPrompts: (prompts: any) => void;
 }
 
 export const PromptContext = createContext<PromptContextType>({
-  originalPrompt: null,
-  currentPrompt: null,
-  setOriginalPrompt: () => {},
-  setCurrentPrompt: () => {},
+  originalPrompts: null,
+  currentPrompts: null,
+  setOriginalPrompts: () => {},
+  setCurrentPrompts: () => {},
 });
 
 export const usePrompt = () => useContext(PromptContext);
 
 function ConfigForm({ config, onSubmit }: ConfigFormProps) {
-  const [prompt, setPrompt] = useState<any>(null);
-  const { setOriginalPrompt } = usePrompt();
+  const [prompts, setPrompts] = useState<any[]>([]);
+  const { setOriginalPrompts } = usePrompt();
   const [videoDevices, setVideoDevices] = useState<VideoDevice[]>([]);
-  const [selectedDevice, setSelectedDevice] = useState<string | undefined>(
-    config.selectedDeviceId
-  );
+  const [audioDevices, setAudioDevices] = useState<VideoDevice[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<string | undefined>(config.selectedDeviceId);
+  const [selectedAudioDevice, setSelectedAudioDevice] = useState<string | undefined>(config.selectedDeviceId);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -150,38 +152,78 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
    */
   const getVideoDevices = useCallback(async () => {
     try {
-      // Get Available Video Devices.
-      await navigator.mediaDevices.getUserMedia({ video: true });
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const videoDevices = devices
-        .filter((device) => device.kind === "videoinput")
-        .map((device) => ({
-          deviceId: device.deviceId,
-          label: device.label || `Camera ${device.deviceId.slice(0, 5)}...`,
-        }));
-      setVideoDevices(videoDevices);
+      await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
 
-      // Use first device as default and remove selected device if unavailable.
-      if (!videoDevices.some((device) => device.deviceId === selectedDevice)) {
-        setSelectedDevice(videoDevices.length > 0 ? videoDevices[0].deviceId : undefined);
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = [
+        { deviceId: "none", label: "No Video" },
+        ...devices
+          .filter((device) => device.kind === "videoinput")
+          .map((device) => ({
+            deviceId: device.deviceId,
+            label: device.label || `Camera ${device.deviceId.slice(0, 5)}...`,
+          }))
+      ];
+
+      setVideoDevices(videoDevices);
+      // Set default to first available camera if no selection yet
+      if (!selectedDevice && videoDevices.length > 1) {
+        setSelectedDevice(videoDevices[1].deviceId); // Index 1 because 0 is "No Video"
       }
-    } catch (err){
-      console.log(`Failed to get video devices: ${err}`);
+    } catch (err) {
+      console.error("Failed to get video devices");
+      // If we can't access video devices, still provide the None option
+      const videoDevices = [{ deviceId: "none", label: "No Video" }];
+      setVideoDevices(videoDevices);
+      setSelectedDevice("none");
     }
   }, [selectedDevice]);
+
+  const getAudioDevices = useCallback(async () => {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const audioDevices = [
+        { deviceId: "none", label: "No Audio" },
+        ...devices
+          .filter((device) => device.kind === "audioinput")
+          .map((device) => ({
+            deviceId: device.deviceId,
+            label: device.label || `Microphone ${device.deviceId.slice(0, 5)}...`,
+          }))
+      ];
+
+      setAudioDevices(audioDevices);
+      // Set default to first available microphone if no selection yet
+      if (!selectedAudioDevice && audioDevices.length > 1) {
+        setSelectedAudioDevice(audioDevices[1].deviceId); // Index 1 because 0 is "No Audio"
+      }
+    } catch (err) {
+      console.error("Failed to get audio devices");
+      // If we can't access audio devices, still provide the None option
+      const audioDevices = [{ deviceId: "none", label: "No Audio" }];
+      setAudioDevices(audioDevices);
+      setSelectedAudioDevice("none");
+    }
+  }, [selectedAudioDevice]);
 
   // Handle device change events.
   useEffect(() => {
     getVideoDevices();
+    getAudioDevices();
     navigator.mediaDevices.addEventListener("devicechange", getVideoDevices);
+    navigator.mediaDevices.addEventListener("devicechange", getAudioDevices);
 
     return () => {
       navigator.mediaDevices.removeEventListener(
         "devicechange",
         getVideoDevices
       );
+      navigator.mediaDevices.removeEventListener(
+        "devicechange",
+        getAudioDevices
+      );
     };
-  }, [getVideoDevices]);
+  }, [getVideoDevices, getAudioDevices]);
 
   const handleSubmit = (values: z.infer<typeof formSchema>) => {
     onSubmit({
@@ -189,22 +231,27 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
       streamUrl: values.streamUrl
         ? values.streamUrl.replace(/\/+$/, "")
         : values.streamUrl,
-      prompt,
+      prompts: prompts,
       selectedDeviceId: selectedDevice,
+      selectedAudioDeviceId: selectedAudioDevice,
     });
   };
 
-  const handlePromptChange = async (e: any) => {
-    const file = e.target.files[0];
-    if (!file) return;
+  const handlePromptsChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.length) return;
 
     try {
-      const text = await file.text();
-      const parsedPrompt = JSON.parse(text);
-      setPrompt(parsedPrompt);
-      setOriginalPrompt(parsedPrompt);
+      const files = Array.from(e.target.files);
+      const fileReads = files.map(async (file) => {
+        const text = await file.text();
+        return JSON.parse(text);
+      });
+
+      const allPrompts = await Promise.all(fileReads);
+      setPrompts(allPrompts);
+      setOriginalPrompts(allPrompts);
     } catch (err) {
-      console.error(err);
+      console.error("Failed to parse one or more JSON files.", err);
     }
   };
 
@@ -257,10 +304,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             onValueChange={handleCameraSelect}
           >
             <Select.Trigger className="w-full mt-2">
-              {videoDevices.length === 0
-                ? "No camera devices found"
-                : videoDevices.find((d) => d.deviceId === selectedDevice)
-                    ?.label || "Select camera"}
+              {selectedDevice ? (videoDevices.find((d) => d.deviceId === selectedDevice)?.label || "None") : "None"}
             </Select.Trigger>
             <Select.Content>
               {videoDevices.length === 0 ? (
@@ -278,14 +322,30 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
           </Select>
         </div>
 
+        <div className="mt-4 mb-4">
+          <Label>Microphone</Label>
+          <Select value={selectedAudioDevice} onValueChange={setSelectedAudioDevice}>
+            <Select.Trigger className="w-full mt-2">
+              {selectedAudioDevice ? (audioDevices.find((d) => d.deviceId === selectedAudioDevice)?.label || "None") : "None"}
+            </Select.Trigger>
+            <Select.Content>
+              {audioDevices.map((device) => (
+                <Select.Option key={device.deviceId} value={device.deviceId}>
+                  {device.label}
+                </Select.Option>
+              ))}
+            </Select.Content>
+          </Select>
+        </div>
+
         <div className="mt-4 mb-4 grid max-w-sm items-center gap-3">
-          <Label>Comfy Workflow</Label>
+          <Label>Comfy Workflows</Label>
           <Input
-            id="workflow"
+            id="video-workflow"
             type="file"
             accept=".json"
-            onChange={handlePromptChange}
-            required={true}
+            multiple
+            onChange={handlePromptsChange}
           />
         </div>
 

--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -195,7 +195,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
       setAudioDevices(audioDevices);
       // Set default to first available microphone if no selection yet
       if (!selectedAudioDevice && audioDevices.length > 1) {
-        setSelectedAudioDevice(audioDevices[1].deviceId); // Index 1 because 0 is "No Audio"
+        setSelectedAudioDevice(audioDevices[0].deviceId); // Default to "No Audio" for now
       }
     } catch (err) {
       console.error("Failed to get audio devices");

--- a/workflows/audio-tensor-utils-example-workflow.json
+++ b/workflows/audio-tensor-utils-example-workflow.json
@@ -1,0 +1,40 @@
+{
+    "1": {
+      "inputs": {
+        "buffer_size": 500.0
+      },
+      "class_type": "LoadAudioTensor",
+      "_meta": {
+        "title": "Load Audio Tensor"
+      }
+    },
+    "2": {
+      "inputs": {
+        "audio": [
+          "1",
+          0
+        ],
+        "sample_rate": [
+          "1",
+          1
+        ],
+        "pitch_shift": 4.0
+      },
+      "class_type": "PitchShifter",
+      "_meta": {
+        "title": "Pitch Shift"
+      }
+    },
+    "3": {
+      "inputs": {
+        "audio": [
+          "2",
+          0
+        ]
+      },
+      "class_type": "SaveAudioTensor",
+      "_meta": {
+        "title": "Save Audio Tensor"
+      }
+    }
+}


### PR DESCRIPTION
This PR aims to add audio support to comfystream. It adds the following functionalities

1. Instead of invoking queue_prompt after each frame push, it's now run in a loop and queue connects stream track and comfyui workflow, audio and video get to server at different rates to invoking queue_prompt after pushing each frame isn't feasible

2. Can select 3 kinds of permutations with two tracks video and audio (video only, audio only, video + audio)

3. Ability to run multiple prompts concurrently -- the reason for this is we don't want one workflow(prompt) to affect another prompt (this occurs mostly due to buffering which is mostly needed in audio workflows), also if two workflows are not dependent, they should be run on separate threads for concurrency 

Future Work:

1. Explore one-to-many queuing system as it is required in cases where multiple workflows might be consuming from the same queue

2. Perfect video, audio alignment when the gap between them is larger than the buffering capacity of webRTC

3. Have a data channel to send text or other datatypes (ASR etc) from server to UI

4. How to handle generative workflows -- cases where there is no input just output