### PR TITLE
Set log level to warning for verbose aiortc logs

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -20,6 +20,8 @@ from pipeline import Pipeline
 from utils import patch_loop_datagram
 
 logger = logging.getLogger(__name__)
+logging.getLogger('aiortc.rtcrtpsender').setLevel(logging.WARNING)
+logging.getLogger('aiortc.rtcrtpreceiver').setLevel(logging.WARNING)
 
 
 MAX_BITRATE = 2000000


### PR DESCRIPTION
This change sets the logging level for `aiortc.rtcrtpsender` and `aiortc.rtcrtpreceiver` to warning so that there are not so many logs to look through. These classes were not logging at the same level as the application