### PR TITLE
refactor: make Comfy Workflow input required

### DIFF
--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -253,6 +253,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             type="file"
             accept=".json"
             onChange={handlePromptChange}
+            required={true}
           />
         </div>
 

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,25 +1,29 @@
-import * as React from "react"
+/**
+ * @file Contains styled input components.
+ */
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
-import { cn } from "@/lib/utils"
+/**
+ * Styled input component.
+ * @param props - Input props.
+ * @param ref - Input ref.
+ */
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, ref) => {
+  return (
+    <input
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 u-ios-text-base u-ios-file-text-base",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 u-ios-text-base u-ios-file-text-base",
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Input.displayName = "Input"
-
-export { Input }
+export { Input };


### PR DESCRIPTION
This commit updates the Comfy Workflow input to be a required field. This change ensures that users must provide a workflow file before starting the stream, which helps mitigate issues due to the current lack of robust error handling.

@eliteprox, @yondonfu another way would to use [load-preview-image-example-workflow](https://github.com/yondonfu/comfystream/blob/main/workflows/load-preview-image-example-workflow.json) when no workflow is required but I think this might cause more confusion.