### PR TITLE
revert tensorrt engine name change in workflow 3

### DIFF
--- a/workflows/ui/3 - SD 1.5 TensorRT workflow.json
+++ b/workflows/ui/3 - SD 1.5 TensorRT workflow.json
@@ -291,7 +291,7 @@
         "Node name for S&R": "TensorRTLoader"
       },
       "widgets_values": [
-        "ComfyUI_STAT_dreamshaper-8-dmd-1kstep-fp8_SD15_$stat-b-1-h-512-w-512_00001_.engine",
+        "static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine",
         "SD15"
       ]
     },


### PR DESCRIPTION
Changes the name of the tensorrt engine used in the example workflow back to the same as that produced by running the Build ONNX/Build Static TensorRT examples or scripts/build_trt.py