### PR TITLE
change DepthAnythingTensorrt engine to match infra

### DIFF
--- a/workflows/ui/3 - SD 1.5 TensorRT workflow.json
+++ b/workflows/ui/3 - SD 1.5 TensorRT workflow.json
@@ -569,7 +569,7 @@
         "Node name for S&R": "DepthAnythingTensorrt"
       },
       "widgets_values": [
-        "depth_anything_v2_vits-fp16.engine"
+        "depth_anything_v2_vitl14-fp16.engine"
       ]
     },
     {


### PR DESCRIPTION
changes `depth_anything_v2_vits-fp16.engine` to `depth_anything_v2_vitl14-fp16.engine` in example SD1.5 workflow to match value deployed to infra