### PR TITLE
Remove kj-nodes and comfyui-manager

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -62,11 +62,6 @@ nodes:
     url: "https://github.com/rgthree/rgthree-comfy.git"
     type: "utility"
 
-  comfyui-kjnodes:
-    name: "ComfyUI KJNodes"
-    url: "https://github.com/kijai/ComfyUI-KJNodes.git"
-    type: "utility"
-
   comfyui-background-edit:
     name: "ComfyUI Background Edit"
     url: "https://github.com/yondonfu/ComfyUI-Background-Edit"

--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -19,11 +19,6 @@ nodes:
     dependencies:
       - "scikit-image"
 
-  comfyui-manager:
-    name: "ComfyUI Manager"
-    url: "https://github.com/ltdrdata/ComfyUI-Manager.git"
-    type: "utility"
-
   comfyui-misc-effects:
     name: "ComfyUI Misc Effects"
     url: "https://github.com/ryanontheinside/ComfyUI-Misc-Effects.git"


### PR DESCRIPTION
Removes kj-nodes and comfyui-manager from nodes.yaml since they are not used in a default workflow