### PR TITLE
chore: enable nextjs https inside vscode config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
             "runtimeExecutable": "npm",
             "runtimeArgs": [
                 "run",
-                "dev"
+                "dev:https"
             ],
             "serverReadyAction": {
                 "pattern": "listening on",


### PR DESCRIPTION
This pull request enables the experimental https server from nextjs, so that people that are running comfystream inside a container can access it outside the container.
