### PR TITLE
add pyproject.toml to remove deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfystream"
-version = "0.1.0"
+version = "0.0.2"
 dependencies = [
     "asyncio",
     "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=64.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "comfystream"
+version = "0.1.0"
+dependencies = [
+    "asyncio",
+    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/yondonfu/comfystream"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = {find = {where = ["src"]}}
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name="comfystream",
-    version="0.0.2",
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    install_requires=[
-        "asyncio",
-        "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",
-    ],
-    extras_require={"dev": ["pytest"]},
-    url="https://github.com/yondonfu/comfystream",
-)
+setup()


### PR DESCRIPTION
This change updates the comfystream package installation to the latest standard. See https://packaging.python.org/en/latest/guides/modernize-setup-py-project/ and additional warning https://github.com/pypa/pip/issues/11457

Resolves https://github.com/yondonfu/comfystream/issues/35