### PR TITLE
Feat: query params

### DIFF
--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -4,9 +4,27 @@ import { Room } from "@/components/room";
 import { PromptContext } from "@/components/settings";
 import { useState, useEffect } from "react";
 
+// Read query params once at page load
+function getQueryParams() {
+  if (typeof window === 'undefined') return null;
+  
+  const searchParams = new URLSearchParams(window.location.search);
+  const frameRateParam = searchParams.get('frameRate');
+  
+  return {
+    streamUrl: searchParams.get('streamUrl'),
+    frameRate: frameRateParam ? parseInt(frameRateParam) : undefined,
+    videoDevice: searchParams.get('videoDevice'),
+    audioDevice: searchParams.get('audioDevice'),
+    workflowUrl: searchParams.get('workflowUrl'),
+    skipDialog: searchParams.get('skipDialog') === 'true'
+  };
+}
+
 export default function Page() {
   const [originalPrompts, setOriginalPrompts] = useState<any>(null);
   const [currentPrompts, setCurrentPrompts] = useState<any>(null);
+  const [queryParams] = useState(getQueryParams); // Read once on mount
 
   // Update currentPrompt whenever originalPrompt changes
   useEffect(() => {
@@ -24,7 +42,7 @@ export default function Page() {
     }}>
       <div className="flex flex-col">
         <div className="w-full">
-          <Room />
+          <Room initialParams={queryParams} />
         </div>
       </div>
     </PromptContext.Provider>

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -10,6 +10,7 @@ function getQueryParams() {
   
   const searchParams = new URLSearchParams(window.location.search);
   const frameRateParam = searchParams.get('frameRate');
+  const workflowParam = searchParams.get('workflow');
   
   return {
     streamUrl: searchParams.get('streamUrl'),
@@ -17,6 +18,7 @@ function getQueryParams() {
     videoDevice: searchParams.get('videoDevice'),
     audioDevice: searchParams.get('audioDevice'),
     workflowUrl: searchParams.get('workflowUrl'),
+    workflow: workflowParam ? JSON.parse(decodeURIComponent(workflowParam)) : undefined,
     skipDialog: searchParams.get('skipDialog') === 'true'
   };
 }

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -6,18 +6,18 @@ import { useState, useEffect } from "react";
 
 // Read query params once at page load
 function getQueryParams() {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === 'undefined') return undefined;
   
   const searchParams = new URLSearchParams(window.location.search);
   const frameRateParam = searchParams.get('frameRate');
   const workflowParam = searchParams.get('workflow');
   
   return {
-    streamUrl: searchParams.get('streamUrl'),
+    streamUrl: searchParams.get('streamUrl') || undefined,
     frameRate: frameRateParam ? parseInt(frameRateParam) : undefined,
-    videoDevice: searchParams.get('videoDevice'),
-    audioDevice: searchParams.get('audioDevice'),
-    workflowUrl: searchParams.get('workflowUrl'),
+    videoDevice: searchParams.get('videoDevice') || undefined,
+    audioDevice: searchParams.get('audioDevice') || undefined,
+    workflowUrl: searchParams.get('workflowUrl') || undefined,
     workflow: workflowParam ? JSON.parse(decodeURIComponent(workflowParam)) : undefined,
     skipDialog: searchParams.get('skipDialog') === 'true'
   };

--- a/ui/src/components/room.tsx
+++ b/ui/src/components/room.tsx
@@ -161,6 +161,9 @@ interface RoomProps {
     frameRate?: number;
     videoDevice?: string;
     audioDevice?: string;
+    workflowUrl?: string;
+    workflow?: any;
+    skipDialog?: boolean;
   };
 }
 
@@ -183,6 +186,7 @@ export const Room = ({ initialParams }: RoomProps) => {
       ...(initialParams?.frameRate ? { frameRate: initialParams.frameRate } : {}),
       ...(initialParams?.videoDevice ? { selectedVideoDeviceId: initialParams.videoDevice } : {}),
       ...(initialParams?.audioDevice ? { selectedAudioDeviceId: initialParams.audioDevice } : {}),
+      ...(initialParams?.workflow ? { prompts: [initialParams.workflow] } : {}),
     };
     console.log('Room: initializing with params:', initialParams);
     console.log('Room: initial config:', config);

--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -63,22 +63,16 @@ interface StreamSettingsProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (config: StreamConfig) => void;
+  currentConfig?: StreamConfig;
 }
 
 export function StreamSettings({
   open,
   onOpenChange,
   onSave,
+  currentConfig,
 }: StreamSettingsProps) {
   const isDesktop = useMediaQuery("(min-width: 768px)");
-
-  const [config, setConfig] = useState<StreamConfig>(DEFAULT_CONFIG);
-
-  const handleSubmit = (config: StreamConfig) => {
-    setConfig(config);
-    onSave(config);
-    onOpenChange(false);
-  };
 
   if (isDesktop) {
     return (
@@ -89,7 +83,7 @@ export function StreamSettings({
               <div className="mt-4">Stream Settings</div>
             </DialogTitle>
           </DialogHeader>
-          <ConfigForm config={config} onSubmit={handleSubmit} />
+          <ConfigForm onSubmit={onSave} currentConfig={currentConfig} />
         </DialogContent>
       </Dialog>
     );
@@ -102,7 +96,7 @@ export function StreamSettings({
           <DrawerTitle>Stream Settings</DrawerTitle>
         </DrawerHeader>
         <div className="px-4">
-          <ConfigForm config={config} onSubmit={handleSubmit} />
+          <ConfigForm onSubmit={onSave} currentConfig={currentConfig} />
         </div>
       </DrawerContent>
     </Drawer>
@@ -115,8 +109,8 @@ const formSchema = z.object({
 });
 
 interface ConfigFormProps {
-  config: StreamConfig;
   onSubmit: (config: StreamConfig) => void;
+  currentConfig?: StreamConfig;
 }
 
 interface PromptContextType {
@@ -135,17 +129,24 @@ export const PromptContext = createContext<PromptContextType>({
 
 export const usePrompt = () => useContext(PromptContext);
 
-function ConfigForm({ config, onSubmit }: ConfigFormProps) {
+function ConfigForm({ onSubmit, currentConfig }: ConfigFormProps) {
   const [prompts, setPrompts] = useState<any[]>([]);
   const { setOriginalPrompts } = usePrompt();
   const [videoDevices, setVideoDevices] = useState<AVDevice[]>([]);
   const [audioDevices, setAudioDevices] = useState<AVDevice[]>([]);
-  const [selectedVideoDevice, setSelectedVideoDevice] = useState<string | undefined>(config.selectedVideoDeviceId);
-  const [selectedAudioDevice, setSelectedAudioDevice] = useState<string | undefined>(config.selectedAudioDeviceId);
+  const [selectedVideoDevice, setSelectedVideoDevice] = useState<string | undefined>(
+    currentConfig?.selectedVideoDeviceId || DEFAULT_CONFIG.selectedVideoDeviceId
+  );
+  const [selectedAudioDevice, setSelectedAudioDevice] = useState<string | undefined>(
+    currentConfig?.selectedAudioDeviceId || DEFAULT_CONFIG.selectedAudioDeviceId
+  );
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: config,
+    defaultValues: {
+      streamUrl: currentConfig?.streamUrl || DEFAULT_CONFIG.streamUrl,
+      frameRate: currentConfig?.frameRate || DEFAULT_CONFIG.frameRate,
+    },
   });
 
   /**

--- a/ui/src/hooks/use-query-params.ts
+++ b/ui/src/hooks/use-query-params.ts
@@ -1,0 +1,30 @@
+// Read params directly from window.location.search
+const cachedParams = typeof window !== 'undefined' ? (() => {
+  console.log('Reading query params from:', window.location.search);
+  const searchParams = new URLSearchParams(window.location.search);
+  const frameRateParam = searchParams.get('frameRate');
+  
+  const params = {
+    streamUrl: searchParams.get('streamUrl'),
+    frameRate: frameRateParam ? parseInt(frameRateParam) : undefined,
+    videoDevice: searchParams.get('videoDevice'),
+    audioDevice: searchParams.get('audioDevice'),
+    workflowUrl: searchParams.get('workflowUrl'),
+    skipDialog: searchParams.get('skipDialog') === 'true'
+  };
+  console.log('Parsed params:', params);
+  return params;
+})() : {
+  streamUrl: null,
+  frameRate: undefined,
+  videoDevice: null,
+  audioDevice: null,
+  workflowUrl: null,
+  skipDialog: false
+};
+
+// Just return the cached params
+export function useQueryParams() {
+  console.log('useQueryParams called, returning:', cachedParams);
+  return cachedParams;
+} 


### PR DESCRIPTION
# Add URL Parameter Handling

## Changes
- Added support for passing all StreamSettings as individual query parameters
- Added support for when all stream settings are provided, along with 'skipDialog=true', the dialog is skipped and the stream is launched
- Added support for passing serialized ComfyUI workflows directly via URL using the `workflow` parameter

### note: 
if no parameters are provided, the application continues using DEFAULT_CONFIG
## Example Usage
http://localhost:3001/?streamUrl=http://127.0.0.1:6666/rando&frameRate=42069