### PR TITLE
improvement: single python environment

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,9 +2,33 @@ import os
 import subprocess
 import argparse
 import logging
+import pathlib
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+def ensure_init_files(workspace: str):
+    """Create __init__.py files in comfy/ and comfy_extras/ directories if they don't exist"""
+    base_dirs = ['comfy', 'comfy_extras']
+    for base_dir in base_dirs:
+        base_path = os.path.join(workspace, base_dir)
+        if not os.path.exists(base_path):
+            continue
+            
+        # Create __init__.py in the root of base_dir first
+        root_init = os.path.join(base_path, "__init__.py")
+        if not os.path.exists(root_init):
+            logger.info(f"Creating {root_init}")
+            with open(root_init, 'w') as f:
+                f.write("")
+                
+        # Then walk subdirectories
+        for root, dirs, files in os.walk(base_path):
+            init_path = os.path.join(root, "__init__.py")
+            if not os.path.exists(init_path):
+                logger.info(f"Creating {init_path}")
+                with open(init_path, 'w') as f:
+                    f.write("")
 
 def install_custom_node_req(workspace: str):
     custom_nodes_path = os.path.join(workspace, "custom_nodes")
@@ -26,4 +50,8 @@ if __name__ == "__main__":
 
     logger.info("Installing custom node requirements...")
     install_custom_node_req(args.workspace)
-    logger.info("Custom node requirements installed successfully.")
+    
+    logger.info("Ensuring __init__.py files exist in ComfyUI directories...")
+    ensure_init_files(args.workspace)
+    
+    logger.info("Installation completed successfully.")


### PR DESCRIPTION
This allows for vanilla ComfyUI and the Hiddenswitch fork to be installed and used in the same python environment. This is based directly on the advice of the author of the Hiddenswitch fork.

Without this fix, we get messages like the following when starting ComfyUI in the same python environment as Hiddenswitch:

`AttributeError: module 'comfy.utils' has no attribute 'set_progress_bar_global_hook'. Did you mean: 'set_progress_bar_enabled'?
`
and 
`ModuleNotFoundError: No module named 'comfy_extras.nodes_slg'`

These errors occur because Python's module system requires proper `__init__.py` files to recognize directories as packages, and the current setup doesn't ensure these files exist in all necessary directories. Thus far, the solution has been maintaining two separate python environments... One for ComfyUI and one for ComfyStream.

## Solution
Added a new `ensure_init_files()` function to `install.py` that creates missing `__init__.py` files in the `comfy/` and `comfy_extras/` directories and their subdirectories. 

## Testing
To test this change:
1. Install both vanilla ComfyUI and Hiddenswitch fork in the same Python environment
2. Try to start ComfyUI and notice errors like those specified above
3. Run install.py
4. Start ComfyUI again and notice that it starts successfully 

