### PR TITLE
chore: add publisher-id for registry publication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dev = ["pytest"]
 repository = "https://github.com/yondonfu/comfystream"
 
 [tool.comfy]
-PublisherId = "" # TODO (fill in Publisher ID from Comfy Registry Website).
-DisplayName = "ComfyStream" # Display name for the Custom Node. Can be changed later.
+PublisherId = "livepeer-comfystream"
+DisplayName = "ComfyStream"
 Icon = "https://avatars.githubusercontent.com/u/25355022?s=48&v=4" # SVG, PNG, JPG or GIF (MAX. 800x400px)
 
 [tool.setuptools]


### PR DESCRIPTION
Adds a publisher id for publishing the node to the registry