### PR TITLE
fix: open UI in new tab

### DIFF
--- a/nodes/api/__init__.py
+++ b/nodes/api/__init__.py
@@ -143,39 +143,6 @@ if hasattr(PromptServer.instance, 'routes') and hasattr(PromptServer.instance.ro
             
             return web.json_response({"error": str(e)}, status=500)
 
-    @routes.post('/launch_comfystream')
-    async def launch_comfystream(request):
-        """Open the ComfyStream UI in a new browser tab"""
-        try:
-            data = await request.json()
-            settings = data.get("settings", {})
-            
-            # Get the current server status
-            status = server_manager.get_status()
-            
-            # Determine the URL based on server status
-            if status["running"]:
-                # If server is running, use its host and port
-                host = status["host"]
-                port = status["port"]
-            else:
-                # Otherwise use the settings
-                host = settings.get("host", "localhost")
-                port = settings.get("port", 8889)
-            
-            # Format the URL properly (use localhost instead of 0.0.0.0 for browser)
-            browser_host = "localhost" if host == "0.0.0.0" else host
-            
-            # Open browser to the static UI using the dynamic extension name
-            webbrowser.open(f"http://{browser_host}:8188{STATIC_ROUTE}/index.html")
-            return web.json_response({
-                "success": True,
-                "url": f"http://{browser_host}:8188{STATIC_ROUTE}/index.html"
-            })
-        except Exception as e:
-            logging.error(f"Error launching ComfyStream UI: {str(e)}")
-            return web.json_response({"error": str(e)}, status=500)
-
     @routes.get('/comfystream/settings')
     async def get_settings(request):
         """Get ComfyStream settings"""

--- a/nodes/web/js/comfystream_ui_preview_node.js
+++ b/nodes/web/js/comfystream_ui_preview_node.js
@@ -73,15 +73,22 @@ app.registerExtension({
                 
                 // Add a button to launch the UI in a new tab
                 this.addWidget("button", "Open in New Tab", null, () => {
-                    // Use the same endpoint as the launcher node
-                    fetch('/launch_comfystream', {
-                        method: 'POST',
+                    // Get extension info which contains the correct UI URL
+                    fetch('/comfystream/extension_info', {
+                        method: 'GET',
                         headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify({})
+                            'Accept': 'application/json'
+                        }
                     })
                     .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                            // Use the current origin with the static route
+                            const uiUrl = `${window.location.origin}${data.static_route}/index.html`;
+                            // Open the URL in a new tab
+                            window.open(uiUrl, '_blank');
+                        }
+                    })
                     .catch(error => {
                         console.error("[ComfyStream] Error launching UI:", error);
                     });

--- a/nodes/web/js/comfystream_ui_preview_node.js
+++ b/nodes/web/js/comfystream_ui_preview_node.js
@@ -31,19 +31,20 @@ app.registerExtension({
                         .then(response => response.json())
                         .then(data => {
                             if (data.success) {
-                                this.iframe.src = data.ui_url;
+                                // Use the current origin with the static route from extension_info
+                                this.iframe.src = `${window.location.origin}${data.static_route}/index.html`;
                             } else {
                                 console.error("[ComfyStream] Error getting extension info:", data.error);
                                 // Fallback to hardcoded path
-                                const extensionName = "ComfyStream";
-                                this.iframe.src = `/extensions/${extensionName}/static/index.html`;
+                                const extensionName = "comfystream";
+                                this.iframe.src = `${window.location.origin}/extensions/${extensionName}/static/index.html`;
                             }
                         })
                         .catch(error => {
                             console.error("[ComfyStream] Error fetching extension info:", error);
                             // Fallback to hardcoded path
-                            const extensionName = "comfystream_inside";
-                            this.iframe.src = `/extensions/${extensionName}/static/index.html`;
+                            const extensionName = "comfystream";
+                            this.iframe.src = `${window.location.origin}/extensions/${extensionName}/static/index.html`;
                         });
                 };
                 

--- a/nodes/web/js/launcher.js
+++ b/nodes/web/js/launcher.js
@@ -189,7 +189,6 @@ async function openUI() {
         }
 
         const data = await response.json();
-        data.url = "./extensions/comfystream/static/index.html"
         if (!data.success) {
             throw new Error(data.error || 'Unknown error getting ComfyStream UI info');
         }


### PR DESCRIPTION
## Problem
When running on RunPod, clicking the "Open ComfyStream UI" button failed to open the UI in a new tab. This was caused by:

1. The backend using `webbrowser.open()` which only works locally
2. Not accounting for RunPod's proxy URL structure (e.g., `https://zsxfe3108tiubt-8188.proxy.runpod.net/`)

## Solution
- Removed server-side browser opening logic
- Updated client-side code to use `window.location.origin` to get the current base URL
- Standardized all UI opening code to use the `/comfystream/extension_info` endpoint
- Removed the now-redundant `/launch_comfystream` endpoint
- Updated both the menu launcher and UI preview node to use the same approach

This fix ensures the UI opens correctly in both local and RunPod environments without environment-specific code.

supersedes #108 