### PR TITLE
fix: mediapipe conflict with protbuf in ComfyUI_TensorRT

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -2,9 +2,12 @@ nodes:
   # Core TensorRT nodes
   comfyui-tensorrt:
     name: "ComfyUI TensorRT"
-    url: "https://github.com/yondonfu/ComfyUI_TensorRT"
-    branch: "quantization_with_controlnet_fixes"
+    url: "https://github.com/eliteprox/ComfyUI_TensorRT.git"
+    branch: "fix/onnxconverter-converter"
     type: "tensorrt"
+    dependencies: 
+      - "onnxruntime-gpu>=1.17.0"
+      - "onnx>=1.17.0"
 
   comfyui-depthanything-tensorrt:
     name: "ComfyUI DepthAnything TensorRT"
@@ -66,5 +69,3 @@ nodes:
     name: "ComfyUI ControlNet Auxiliary"
     url: "https://github.com/Fannovel16/comfyui_controlnet_aux"
     type: "utility"
-    dependencies: 
-      - "mediapipe==0.10.8"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -49,7 +49,6 @@ RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream pi
 RUN ln -s /workspace/comfystream /workspace/ComfyUI/custom_nodes/comfystream
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream python install.py --workspace /workspace/ComfyUI
 RUN conda run -n comfystream --no-capture-output pip install --upgrade tensorrt-cu12-bindings tensorrt-cu12-libs --root-user-action=ignore
-RUN conda run -n comfystream --no-capture-output pip install mediapipe==0.10.8 --root-user-action=ignore
 
 # Configure no environment activation by default
 RUN conda config --set auto_activate_base false


### PR DESCRIPTION
This change unpins `mediapipe==0.10.8` which was previously done to enable ComfyUI MediaPipe ControlNets https://github.com/yondonfu/comfystream/pull/78#issuecomment-2675094698
