### PR TITLE
fix: add missing LLM folder

### DIFF
--- a/src/comfystream/scripts/setup_models.py
+++ b/src/comfystream/scripts/setup_models.py
@@ -88,6 +88,7 @@ def setup_directories(workspace_dir):
         "vae",
         "tensorrt",
         "unet",
+        "LLM",
     ]
     for dir_name in model_dirs:
         (models_dir / dir_name).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This issue resolves an error with ComfyUI missing the models/LLM folder due to volume mount override.

We can alternatively add the Florence2 model to `models.yaml` if preferred
```
[ERROR] An error occurred while retrieving information for the 'Florence2ModelLoader' node.

Traceback (most recent call last):

  File "/workspace/ComfyUI/server.py", line 591, in get_object_info

    out[x] = node_info(x)

             ^^^^^^^^^^^^

  File "/workspace/ComfyUI/server.py", line 558, in node_info

    info['input'] = obj_class.INPUT_TYPES()

                    ^^^^^^^^^^^^^^^^^^^^^^^

  File "/workspace/ComfyUI/custom_nodes/ComfyUI-Florence2-Vision/nodes.py", line 169, in INPUT_TYPES

    "model": ([item.name for item in Path(folder_paths.models_dir, "LLM").iterdir() if item.is_dir()], {"tooltip": "models are expected to be in Comfyui/models folder"}),

              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/workspace/ComfyUI/custom_nodes/ComfyUI-Florence2-Vision/nodes.py", line 169, in <listcomp>

    "model": ([item.name for item in Path(folder_paths.models_dir, "LLM").iterdir() if item.is_dir()], {"tooltip": "models are expected to be in Comfyui/models folder"}),

              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/workspace/miniconda3/envs/comfystream/lib/python3.11/pathlib.py", line 931, in iterdir

    for name in os.listdir(self):

                ^^^^^^^^^^^^^^^^

FileNotFoundError: [Errno 2] No such file or directory: '/workspace/ComfyUI/models/LLM'
```