### PR TITLE
fix: ensure patched torch graph is always synced on inference errors

### DIFF
--- a/nodes/tensor_utils/prestartup_script.py
+++ b/nodes/tensor_utils/prestartup_script.py
@@ -39,6 +39,7 @@ def patch_controlnet_for_stream():
                 return result
             except Exception as e:
                 print(f"Error: Failed to clone ControlNet during inference: {str(e)}")
+                raise e
             finally:
                 # Mark CUDA graph step at end
                 if torch.cuda.is_available() and hasattr(torch.compiler, 'cudagraph_mark_step_begin'):

--- a/nodes/tensor_utils/prestartup_script.py
+++ b/nodes/tensor_utils/prestartup_script.py
@@ -37,6 +37,8 @@ def patch_controlnet_for_stream():
                     for k, v in result.items()
                 }
                 return result
+            except Exception as e:
+                print(f"Error: Failed to clone ControlNet during inference: {str(e)}")
             finally:
                 # Mark CUDA graph step at end
                 if torch.cuda.is_available() and hasattr(torch.compiler, 'cudagraph_mark_step_begin'):

--- a/nodes/tensor_utils/prestartup_script.py
+++ b/nodes/tensor_utils/prestartup_script.py
@@ -28,21 +28,21 @@ def patch_controlnet_for_stream():
                 }
                
             # Get result from original merge function
-            result = original_control_merge(self, control, control_prev, output_dtype)
-           
-            # Clone all output tensors
-            result = {
-                k: [t.clone() if t is not None else None for t in v]
-                for k, v in result.items()
-            }
-           
-            # Mark CUDA graph step at end
-            if torch.cuda.is_available() and hasattr(torch.compiler, 'cudagraph_mark_step_begin'):
-                torch.compiler.cudagraph_mark_step_begin()
-                torch.cuda.synchronize()
-               
-            return result
-           
+            try:
+                result = original_control_merge(self, control, control_prev, output_dtype)
+            
+                # Clone all output tensors
+                result = {
+                    k: [t.clone() if t is not None else None for t in v]
+                    for k, v in result.items()
+                }
+                return result
+            finally:
+                # Mark CUDA graph step at end
+                if torch.cuda.is_available() and hasattr(torch.compiler, 'cudagraph_mark_step_begin'):
+                    torch.compiler.cudagraph_mark_step_begin()
+                    torch.cuda.synchronize()
+
         # Apply the patch
         ControlBase.control_merge = wrapped_control_merge
         print("Successfully patched ControlNet for torch.compile() compatibility")


### PR DESCRIPTION
This pull request ensures that the patched torch graph remains synchronized even when an error occurs during inference, preventing potential inconsistencies.
