### PR TITLE
fix: default input device selection

### DIFF
--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -272,22 +272,14 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
    * @param deviceId
    */
   const handleCameraSelect = (deviceId: string) => {
-    if (deviceId !== selectedVideoDevice) {
+    if (deviceId !== "" && deviceId !== selectedVideoDevice) {
       setSelectedVideoDevice(deviceId);
-      // Unselect audio device when video is selected
-      if (deviceId !== "none") {
-        setSelectedAudioDevice("none");
-      }
     }
   };
 
   const handleMicrophoneSelect = (deviceId: string) => {
-    if (deviceId !== selectedAudioDevice) {
+    if (deviceId !== "" && deviceId !== selectedAudioDevice) {
       setSelectedAudioDevice(deviceId);
-      // Unselect video device when audio is selected
-      if (deviceId !== "none") {
-        setSelectedVideoDevice("none");
-      }
     }
   };
 


### PR DESCRIPTION
Resolves issue with default camera device being selected https://github.com/yondonfu/comfystream/issues/119 by checking for empty values being passed to `handleCameraSelect` from the UI.

Also reverts most of https://github.com/yondonfu/comfystream/pull/82 which wasn't working correctly either. This will unblock the UI for easier development of simultaneous workflows while keeping the audio device default to "No Audio"