### PR TITLE
feat(server): make ComfyUI log level configurable

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -287,7 +287,10 @@ async def on_startup(app: web.Application):
         patch_loop_datagram(app["media_ports"])
 
     app["pipeline"] = Pipeline(
-        cwd=app["workspace"], disable_cuda_malloc=True, gpu_only=True
+        cwd=app["workspace"], 
+        disable_cuda_malloc=True, 
+        gpu_only=True, 
+        comfyui_inference_log_level=app.get("comfui_inference_log_level", None),
     )
     app["pcs"] = set()
     app["video_tracks"] = {}
@@ -327,6 +330,18 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
         help="Include stream ID as a label in Prometheus metrics.",
+    )
+    parser.add_argument(
+        "--comfyui-log-level",
+        default=None,
+        choices=logging._nameToLevel.keys(),
+        help="Set the global logging level for ComfyUI",
+    )
+    parser.add_argument(
+        "--comfyui-inference-log-level",
+        default=None,
+        choices=logging._nameToLevel.keys(),
+        help="Set the logging level for ComfyUI inference",
     )
     args = parser.parse_args()
 
@@ -376,5 +391,12 @@ if __name__ == "__main__":
     def force_print(*args, **kwargs):
         print(*args, **kwargs, flush=True)
         sys.stdout.flush()
+
+    # Allow overriding of ComyfUI log levels.
+    if args.comfyui_log_level:
+        log_level = logging._nameToLevel.get(args.comfyui_log_level.upper())
+        logging.getLogger("comfy").setLevel(log_level)
+    if args.comfyui_inference_log_level:
+        app["comfui_inference_log_level"] = args.comfyui_inference_log_level
 
     web.run_app(app, host=args.host, port=int(args.port), print=force_print)

--- a/server/utils/__init__.py
+++ b/server/utils/__init__.py
@@ -1,2 +1,2 @@
-from .utils import patch_loop_datagram, add_prefix_to_app_routes
+from .utils import patch_loop_datagram, add_prefix_to_app_routes, temporary_log_level
 from .fps_meter import FPSMeter

--- a/server/utils/utils.py
+++ b/server/utils/utils.py
@@ -6,6 +6,7 @@ import types
 import logging
 from aiohttp import web
 from typing import List, Tuple
+from contextlib import asynccontextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -63,3 +64,22 @@ def add_prefix_to_app_routes(app: web.Application, prefix: str):
     for route in list(app.router.routes()):
         new_path = prefix + route.resource.canonical
         app.router.add_route(route.method, new_path, route.handler)
+
+
+@asynccontextmanager
+async def temporary_log_level(logger_name: str, level: int):
+    """Temporarily set the log level of a logger.
+
+    Args:
+        logger_name: The name of the logger to set the level for.
+        level: The log level to set.
+    """
+    if level is not None:
+        logger = logging.getLogger(logger_name)
+        original_level = logger.level
+        logger.setLevel(level)
+    try:
+        yield
+    finally:
+        if level is not None:
+            logger.setLevel(original_level)


### PR DESCRIPTION
This pull request introduces the `comfyui-log-level` and `comfyui-inference-log-level` arguments to the server, allowing users to adjust the log level and reduce excessive logging.

# Performance Profile

To ensure this does not negativelly affect the performance I ran the profiler in https://github.com/yondonfu/comfystream/pull/80 with the https://github.com/yondonfu/comfystream/blob/main/workflows/comfystream/sd15-tensorrt-api.json workflow. The results are shown below.

## With changes

### Without using the CLI arguments

```bash
AVERAGE - CPU: 415.28%, RAM: 14752.30MB, GPU: 52.93%, VRAM: 3548.00MB
```

### With using the Global ComfyUI log CLI argument

```bash
AVERAGE - CPU: 423.68%, RAM: 14779.73MB, GPU: 55.25%, VRAM: 3548.00MB
```

### With using the Inference ComfyUI log CLI argument

```bash
AVERAGE - CPU: 424.22%, RAM: 14763.52MB, GPU: 54.25%, VRAM: 3548.00MB
```

#### Without changes

```bash
AVERAGE - CPU: 412.29%, RAM: 14817.95MB, GPU: 55.45%, VRAM: 3548.00MB
```