### PR TITLE
fix: remove node package install from launch

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,10 +7,16 @@ cd /workspace/comfystream
 echo -e "\e[32mInstalling Comfystream in editable mode...\e[0m"
 /workspace/miniconda3/envs/comfystream/bin/python3 -m pip install -e . --root-user-action=ignore > /dev/null
 
+# Install npm packages if needed
+if [ ! -d "/workspace/comfystream/ui/node_modules" ]; then
+    echo -e "\e[32mInstalling npm packages for Comfystream UI...\e[0m"
+    cd /workspace/comfystream/ui
+    npm install
+fi
+
 if [ ! -d "/workspace/comfystream/nodes/web/static" ]; then
     echo -e "\e[32mBuilding web assets...\e[0m"
     cd /workspace/comfystream/ui
-    npm install
     npm run build
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -62,11 +62,6 @@ if [ "$1" = "--build-engines" ]; then
   shift
 fi
 
-# Install npm packages if needed
-cd /workspace/comfystream/ui
-if [ ! -d "node_modules" ]; then
-  npm install --legacy-peer-deps
-fi
 
 if [ "$1" = "--server" ]; then
   /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.1.0",
+      "version": "0.0.3",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-dialog": "^1.1.6",


### PR DESCRIPTION
This resolves an error with the livepeer/comfystream:latest image unable to start due to missing ui folder. The new docker CI excluded the ui folder from copying to the image, resulting in this error. The folder is not needed in the image any longer, so it can be removed