### PR TITLE
fix: include Prometheus client dependency in project.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
     "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",
-    "toml",
     "aiortc",
     "aiohttp",
+    "toml",
     "twilio",
+    "prometheus_client",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request ensures that the `prometheus-client` dependency is explicitly specified in both `requirements.txt` and `pyproject.toml` for consistency and proper dependency management.
