### PR TITLE
chore: update ComfyUI-TensorRT node to origin branch

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -2,8 +2,8 @@ nodes:
   # Core TensorRT nodes
   comfyui-tensorrt:
     name: "ComfyUI TensorRT"
-    url: "https://github.com/eliteprox/ComfyUI_TensorRT.git"
-    branch: "fix/onnxconverter-converter"
+    url: "https://github.com/yondonfu/ComfyUI_TensorRT.git"
+    branch: "quantization_with_controlnet_fixes"
     type: "tensorrt"
     dependencies: 
       - "onnxruntime-gpu>=1.17.0"


### PR DESCRIPTION
This change reverts the ComfyUI_TensorRT custom node to use the origin branch now that https://github.com/yondonfu/ComfyUI_TensorRT/pull/2 has been merged.

The eliteprox fork was temporarily used in https://github.com/yondonfu/comfystream/pull/126