### PR TITLE
fix: prevent `AssertionError` by setting `max_workers` to 1

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -94,12 +94,11 @@ class VideoStreamTrack(MediaStreamTrack):
             
             # Perform cleanup outside the exception handler
             logger.info("Video frame collection stopped")
-            await self.pipeline.cleanup()
         except asyncio.CancelledError:
             logger.info("Frame collection task cancelled")
-            await self.pipeline.cleanup()
         except Exception as e:
             logger.error(f"Unexpected error in frame collection: {str(e)}")
+        finally:
             await self.pipeline.cleanup()
 
     async def recv(self):
@@ -154,12 +153,11 @@ class AudioStreamTrack(MediaStreamTrack):
             
             # Perform cleanup outside the exception handler
             logger.info("Audio frame collection stopped")
-            await self.pipeline.cleanup()
         except asyncio.CancelledError:
             logger.info("Frame collection task cancelled")
-            await self.pipeline.cleanup()
         except Exception as e:
             logger.error(f"Unexpected error in audio frame collection: {str(e)}")
+        finally:
             await self.pipeline.cleanup()
 
     async def recv(self):

--- a/server/pipeline.py
+++ b/server/pipeline.py
@@ -11,8 +11,7 @@ WARMUP_RUNS = 5
 
 class Pipeline:
     def __init__(self, **kwargs):
-        self.client = ComfyStreamClient(**kwargs, max_workers=5) # TODO: hardcoded max workers, should it be configurable?
-
+        self.client = ComfyStreamClient(**kwargs)
         self.video_incoming_frames = asyncio.Queue()
         self.audio_incoming_frames = asyncio.Queue()
 


### PR DESCRIPTION
This change resolves https://github.com/yondonfu/comfystream/issues/124 which is caused by concurrent worker processes loading the same models in certain workflows.

This change also handles WebRTC data channel errors during frame processing in `app.py` to resolve https://github.com/yondonfu/comfystream/issues/135. Please note these are separate issues.

`max_workers` had been set to `5` in https://github.com/yondonfu/comfystream/pull/10 to allow for more than a single workflow to be executed simultaneously, however, we must refactor the solution to ensure that prompts are always queued to the same worker process, otherwise this error will occur. (See https://github.com/yondonfu/comfystream/issues/73)

This issue was also occurring intermittently midstream due to the active worker process queuing long enough to prompt comfystream api server to start a 2nd worker. 