### PR TITLE
fix(dev): handle NoneType error in monitor script

### DIFF
--- a/scripts/monitor_pid_resources.py
+++ b/scripts/monitor_pid_resources.py
@@ -129,7 +129,7 @@ def find_pid_by_name(name: str) -> int:
         Process ID of the process with the given name.
     """
     for proc in psutil.process_iter(["pid", "name", "cmdline"]):
-        if name in proc.info["cmdline"]:
+        if proc.info["cmdline"] and name in proc.info["cmdline"]:
             found_pid = proc.info["pid"]
             click.echo(
                 click.style(f"Found process '{name}' with PID {found_pid}.", fg="green")


### PR DESCRIPTION
This pull request fixes a NoneType error in the resource monitoring script that occurs when certain processes lack a name.
