### PR TITLE
removing max frameRate fixes error on Safari

### DIFF
--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -170,7 +170,7 @@ export function Webcam({
                 width: { ideal: 512 },
                 height: { ideal: 512 },
                 aspectRatio: { ideal: 1 },
-                frameRate: { ideal: frameRate, max: frameRate },
+                frameRate: { ideal: frameRate },
               },
         audio:
           selectedAudioDeviceId === "none"


### PR DESCRIPTION
fixes #161