### PR TITLE
fix(server): ensure Audio Tensor nodes are properly registered

### DIFF
--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,5 +1,6 @@
 """ComfyStream nodes package"""
 
+from .audio_utils import *
 from .tensor_utils import *
 from .video_stream_utils import *
 from .api import *
@@ -10,7 +11,7 @@ NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
 
 # Import and update mappings from submodules
-for module in [tensor_utils, video_stream_utils, api, web]:
+for module in [audio_utils, tensor_utils, video_stream_utils, api, web]:
     if hasattr(module, 'NODE_CLASS_MAPPINGS'):
         NODE_CLASS_MAPPINGS.update(module.NODE_CLASS_MAPPINGS)
     if hasattr(module, 'NODE_DISPLAY_NAME_MAPPINGS'):


### PR DESCRIPTION
This pull request ensures that Audio Tensor nodes are correctly registered in the `nodes/__init__.py` file, allowing them to be utilized in ComfyStream.
