### PR TITLE
feat: add optimized face mesh estimator

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -69,3 +69,8 @@ nodes:
     name: "ComfyUI ControlNet Auxiliary"
     url: "https://github.com/Fannovel16/comfyui_controlnet_aux"
     type: "utility"
+
+  comfyui-stream-pack:
+    name: "ComfyUI Stream Pack"
+    url: "https://github.com/livepeer/ComfyUI-Stream-Pack"
+    type: "utility"

--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -73,4 +73,5 @@ nodes:
   comfyui-stream-pack:
     name: "ComfyUI Stream Pack"
     url: "https://github.com/livepeer/ComfyUI-Stream-Pack"
+    branch: "expose_feature_bank_to_comfyui"
     type: "utility"

--- a/workflows/comfystream/sd15-multi-cnet-depthanything-face-api.json
+++ b/workflows/comfystream/sd15-multi-cnet-depthanything-face-api.json
@@ -50,7 +50,7 @@
   },
   "7": {
     "inputs": {
-      "seed": 722042942226989,
+      "seed": 1063187251107697,
       "steps": 2,
       "cfg": 1,
       "sampler_name": "lcm",
@@ -225,8 +225,8 @@
         0
       ],
       "image": [
-        "22",
-        0
+        "39",
+        1
       ]
     },
     "class_type": "ControlNetApplyAdvanced",
@@ -256,21 +256,6 @@
     "class_type": "TorchCompileLoadControlNet",
     "_meta": {
       "title": "TorchCompileLoadControlNet"
-    }
-  },
-  "22": {
-    "inputs": {
-      "max_faces": 1,
-      "min_confidence": 0.5,
-      "resolution": 512,
-      "image": [
-        "26",
-        0
-      ]
-    },
-    "class_type": "MediaPipe-FaceMeshPreprocessor",
-    "_meta": {
-      "title": "MediaPipe Face Mesh"
     }
   },
   "26": {
@@ -324,6 +309,27 @@
     "class_type": "ConditioningConcat",
     "_meta": {
       "title": "Conditioning (Concat)"
+    }
+  },
+  "39": {
+    "inputs": {
+      "static_image_mode": false,
+      "max_num_faces": 1,
+      "refine_landmarks": false,
+      "min_detection_confidence": 0.35000000000000003,
+      "min_tracking_confidence": 0.35000000000000003,
+      "draw_mesh": true,
+      "draw_contours": true,
+      "mesh_color": "green",
+      "mesh_thickness": 2,
+      "image": [
+        "26",
+        0
+      ]
+    },
+    "class_type": "FaceMeshNode",
+    "_meta": {
+      "title": "Face Mesh"
     }
   }
 }

--- a/workflows/comfyui/sd15-multi-cnet-depthanything-face.json
+++ b/workflows/comfyui/sd15-multi-cnet-depthanything-face.json
@@ -1,6 +1,6 @@
 {
-  "last_node_id": 38,
-  "last_link_id": 57,
+  "last_node_id": 40,
+  "last_link_id": 60,
   "nodes": [
     {
       "id": 10,
@@ -14,7 +14,7 @@
         106
       ],
       "flags": {},
-      "order": 10,
+      "order": 8,
       "mode": 0,
       "inputs": [
         {
@@ -33,6 +33,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfyui-torch-compile",
+        "ver": "28b36d2569b39c303b2d9b0e5540ec5d628164af",
         "Node name for S&R": "TorchCompileLoadControlNet"
       },
       "widgets_values": [
@@ -66,6 +68,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "VAELoader"
       },
       "widgets_values": [
@@ -103,6 +107,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfyui-torch-compile",
+        "ver": "28b36d2569b39c303b2d9b0e5540ec5d628164af",
         "Node name for S&R": "TorchCompileLoadVAE"
       },
       "widgets_values": [
@@ -149,6 +155,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "VAEDecode"
       },
       "widgets_values": []
@@ -176,6 +184,8 @@
       ],
       "outputs": [],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "PreviewImage"
       },
       "widgets_values": []
@@ -205,6 +215,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "EmptyLatentImage"
       },
       "widgets_values": [
@@ -225,7 +237,7 @@
         106
       ],
       "flags": {},
-      "order": 11,
+      "order": 9,
       "mode": 0,
       "inputs": [
         {
@@ -244,159 +256,14 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfyui-torch-compile",
+        "ver": "28b36d2569b39c303b2d9b0e5540ec5d628164af",
         "Node name for S&R": "TorchCompileLoadControlNet"
       },
       "widgets_values": [
         "inductor",
         false,
         "reduce-overhead"
-      ]
-    },
-    {
-      "id": 22,
-      "type": "MediaPipe-FaceMeshPreprocessor",
-      "pos": [
-        515,
-        1074
-      ],
-      "size": [
-        315,
-        106
-      ],
-      "flags": {},
-      "order": 9,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 46
-        }
-      ],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            44
-          ]
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "MediaPipe-FaceMeshPreprocessor"
-      },
-      "widgets_values": [
-        1,
-        0.5,
-        512
-      ]
-    },
-    {
-      "id": 26,
-      "type": "LoadImage",
-      "pos": [
-        100,
-        1142
-      ],
-      "size": [
-        315,
-        314
-      ],
-      "flags": {},
-      "order": 2,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            24,
-            46
-          ]
-        },
-        {
-          "name": "MASK",
-          "type": "MASK",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "LoadImage"
-      },
-      "widgets_values": [
-        "example.png",
-        "image"
-      ]
-    },
-    {
-      "id": 18,
-      "type": "CLIPSetLastLayer",
-      "pos": [
-        515,
-        1310
-      ],
-      "size": [
-        315,
-        58
-      ],
-      "flags": {},
-      "order": 12,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "clip",
-          "type": "CLIP",
-          "link": 47
-        }
-      ],
-      "outputs": [
-        {
-          "name": "CLIP",
-          "type": "CLIP",
-          "links": [
-            25,
-            26
-          ]
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "CLIPSetLastLayer"
-      },
-      "widgets_values": [
-        -2
-      ]
-    },
-    {
-      "id": 3,
-      "type": "TensorRTLoader",
-      "pos": [
-        100,
-        130
-      ],
-      "size": [
-        315,
-        82
-      ],
-      "flags": {},
-      "order": 3,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "MODEL",
-          "type": "MODEL",
-          "links": [
-            27
-          ]
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "TensorRTLoader"
-      },
-      "widgets_values": [
-        "static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine",
-        "SD15"
       ]
     },
     {
@@ -411,7 +278,7 @@
         106.31529998779297
       ],
       "flags": {},
-      "order": 4,
+      "order": 2,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -424,6 +291,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "ControlNetLoader"
       },
       "widgets_values": [
@@ -442,7 +311,7 @@
         58
       ],
       "flags": {},
-      "order": 5,
+      "order": 3,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -455,6 +324,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "ControlNetLoader"
       },
       "widgets_values": [
@@ -473,7 +344,7 @@
         58
       ],
       "flags": {},
-      "order": 8,
+      "order": 11,
       "mode": 0,
       "inputs": [
         {
@@ -492,6 +363,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "depth-anything-tensorrt",
+        "ver": "ede57bac05059731f955c1b1563af2c1947f999a",
         "Node name for S&R": "DepthAnythingTensorrt"
       },
       "widgets_values": [
@@ -510,7 +383,7 @@
         98
       ],
       "flags": {},
-      "order": 6,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -523,6 +396,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "CLIPLoader"
       },
       "widgets_values": [
@@ -564,6 +439,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "CLIPTextEncode"
       },
       "widgets_values": [
@@ -603,6 +480,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "CLIPTextEncode"
       },
       "widgets_values": [
@@ -655,10 +534,12 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "KSampler"
       },
       "widgets_values": [
-        722042942226989,
+        1063187251107697,
         "randomize",
         2,
         1,
@@ -704,8 +585,11 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "ConditioningConcat"
-      }
+      },
+      "widgets_values": []
     },
     {
       "id": 9,
@@ -768,6 +652,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "ControlNetApplyAdvanced"
       },
       "widgets_values": [
@@ -809,7 +695,7 @@
         {
           "name": "image",
           "type": "IMAGE",
-          "link": 44
+          "link": 59
         },
         {
           "name": "vae",
@@ -837,6 +723,8 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "ControlNetApplyAdvanced"
       },
       "widgets_values": [
@@ -882,8 +770,179 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
         "Node name for S&R": "ConditioningConcat"
-      }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 18,
+      "type": "CLIPSetLastLayer",
+      "pos": [
+        495.0350646972656,
+        1554.90380859375
+      ],
+      "size": [
+        315,
+        58
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 47
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            25,
+            26
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
+        "Node name for S&R": "CLIPSetLastLayer"
+      },
+      "widgets_values": [
+        -2
+      ]
+    },
+    {
+      "id": 39,
+      "type": "FaceMeshNode",
+      "pos": [
+        516.9473266601562,
+        1139.9932861328125
+      ],
+      "size": [
+        315,
+        270
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 58
+        }
+      ],
+      "outputs": [
+        {
+          "name": "facemesh_data",
+          "type": "FACEMESH_DATA",
+          "links": null
+        },
+        {
+          "name": "annotations",
+          "type": "IMAGE",
+          "links": [
+            59
+          ],
+          "slot_index": 1
+        }
+      ],
+      "properties": {
+        "aux_id": "livepeer/ComfyUI-Stream-Pack",
+        "ver": "33d26c480871a69676e2dc60e6c097971f0b828e",
+        "Node name for S&R": "FaceMeshNode"
+      },
+      "widgets_values": [
+        false,
+        1,
+        false,
+        0.35000000000000003,
+        0.35000000000000003,
+        true,
+        true,
+        "green",
+        2
+      ]
+    },
+    {
+      "id": 3,
+      "type": "TensorRTLoader",
+      "pos": [
+        101.22982788085938,
+        129.0006103515625
+      ],
+      "size": [
+        344.6938781738281,
+        87.0430679321289
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            27
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "ryanontheinside/ComfyUI_TensorRT",
+        "ver": "cb1e540e5e5e35ec335cce1ba3dee38895217698",
+        "Node name for S&R": "TensorRTLoader"
+      },
+      "widgets_values": [
+        "static-dreamshaper8_SD15_$stat-b-1-h-512-w-512_00001_.engine",
+        "SD15"
+      ]
+    },
+    {
+      "id": 26,
+      "type": "LoadImage",
+      "pos": [
+        100,
+        1142
+      ],
+      "size": [
+        315,
+        314
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            24,
+            58
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "example.png",
+        "image"
+      ]
     }
   ],
   "links": [
@@ -1008,28 +1067,12 @@
       "CONTROL_NET"
     ],
     [
-      44,
-      22,
-      0,
-      19,
-      3,
-      "IMAGE"
-    ],
-    [
       45,
       20,
       0,
       21,
       0,
       "CONTROL_NET"
-    ],
-    [
-      46,
-      26,
-      0,
-      22,
-      0,
-      "IMAGE"
     ],
     [
       47,
@@ -1102,16 +1145,32 @@
       37,
       0,
       "CONDITIONING"
+    ],
+    [
+      58,
+      26,
+      0,
+      39,
+      0,
+      "IMAGE"
+    ],
+    [
+      59,
+      39,
+      1,
+      19,
+      3,
+      "IMAGE"
     ]
   ],
   "groups": [],
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.35049389948139237,
+      "scale": 0.35049389948139253,
       "offset": [
-        681.8766862163892,
-        500.01545083988316
+        1142.0410253708058,
+        405.4613460138569
       ]
     }
   },


### PR DESCRIPTION
This change introduces an update to the main workflow that uses a new and optimized face mesh estimating node as opposed to the existing community implementation. 

The optimized node was implemented from scratch, and increases FPS by 37.5% in my environment.

The optimized node has been added to the nascent ComfyUI-Stream-Pack repo; it's integration to the main branch of that repo is pending. In the meantime, use the following branch when installing the nodes for testing this workflow:

https://github.com/livepeer/ComfyUI-Stream-Pack/tree/expose_feature_bank_to_comfyui


cc: @rickstaa 