### PR TITLE
docs: improve issue templates to point to upstream

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug report
+    url: https://github.com/livepeer/comfystream/issues
+    about: Please report bugs on our upstream issue tracker.
+  - name: Feature request
+    url: https://github.com/livepeer/comfystream/issues
+    about: Please request features on our upstream issue tracker.
+  - name: Question
+    url: https://github.com/livepeer/comfystream/discussions/234
+    about: Have a question? Ask them on our upstream discussions page.


### PR DESCRIPTION
This pull requests updates the issue templates to prevent issues and questions from being lost.

@eliteprox similar to the admonition we have to ensure that we don't merge these 3 commits back to the fork.