### PR TITLE
feat: add Enable Passthrough checkbox to Stream Settings

### DIFF
--- a/ui/src/components/settings.tsx
+++ b/ui/src/components/settings.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -180,6 +181,7 @@ export const PromptContext = createContext<PromptContextType>({
 export const usePrompt = () => useContext(PromptContext);
 
 function ConfigForm({ config, onSubmit }: ConfigFormProps) {
+  const [enablePassthrough, setEnablePassthrough] = useState(false);
   const [prompts, setPrompts] = useState<Prompt[]>([]);
   const { setOriginalPrompts } = usePrompt();
   const [videoDevices, setVideoDevices] = useState<AVDevice[]>([]);
@@ -334,6 +336,15 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleSubmit)} autoComplete="off">
+        <div className="flex items-center space-x-2 mt-4">
+          <Checkbox
+            id="enable-passthrough"
+            checked={enablePassthrough}
+            onCheckedChange={(checked) => setEnablePassthrough(checked === true)}
+          />
+          <Label htmlFor="enable-passthrough">Enable Passthrough</Label>
+        </div>
+        
         <FormField
           control={form.control}
           name="streamUrl"
@@ -341,7 +352,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             <FormItem className="mt-4">
               <FormLabel>Stream URL</FormLabel>
               <FormControl>
-                <Input placeholder="Stream URL" {...field} />
+                <Input placeholder="Stream URL" {...field} disabled={enablePassthrough} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -355,7 +366,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             <FormItem className="mt-4">
               <FormLabel>Frame Rate</FormLabel>
               <FormControl>
-                <Input placeholder="Frame Rate" {...field} type="number" />
+                <Input placeholder="Frame Rate" {...field} type="number" disabled={enablePassthrough} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -376,6 +387,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
                     max="2048"
                     step="64"
                     {...field}
+                    disabled={enablePassthrough}
                     onChange={(e) => {
                       const value = parseInt(e.target.value);
                       field.onChange(value);
@@ -400,6 +412,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
                     max="2048"
                     step="64"
                     {...field}
+                    disabled={enablePassthrough}
                     onChange={(e) => {
                       const value = parseInt(e.target.value);
                       field.onChange(value);
@@ -419,6 +432,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             required={selectedAudioDevice == "none" && selectedVideoDevice == "none" ? true : false}
             value={selectedVideoDevice == "none" ? "" : selectedVideoDevice}
             onValueChange={handleCameraSelect}
+            disabled={enablePassthrough}
           >
             <Select.Trigger className="w-full mt-2">
               {selectedVideoDevice
@@ -447,6 +461,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
           <Select
             value={selectedAudioDevice}
             onValueChange={handleMicrophoneSelect}
+            disabled={enablePassthrough}
           >
             <Select.Trigger className="w-full mt-2">
               {selectedAudioDevice
@@ -487,6 +502,7 @@ function ConfigForm({ config, onSubmit }: ConfigFormProps) {
             multiple
             onChange={handlePromptsChange}
             required={true}
+            disabled={enablePassthrough}
           />
         </div>
 

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,35 @@
+/**
+ * @file Contains styled checkbox components.
+ */
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Styled checkbox component.
+ * @param props - Checkbox props.
+ * @param ref - Checkbox ref.
+ */
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };


### PR DESCRIPTION
## Summary
- Add "Enable Passthrough" checkbox to Stream Settings form
- Checkbox appears at the top of the form, defaults to unchecked
- When enabled, disables all other form fields (Stream URL, Frame Rate, Width, Height, Camera, Microphone, Comfy Workflows)
- Created missing checkbox UI component using Radix UI primitives

## Test plan
- [ ] Verify checkbox appears in Stream Settings dialog
- [ ] Confirm checkbox defaults to unchecked state
- [ ] Test that checking the box disables all form fields
- [ ] Test that unchecking the box re-enables all form fields
- [ ] Verify styling matches other UI components

🤖 Generated with [Claude Code](https://claude.ai/code)